### PR TITLE
Optional extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.0.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.1.0]
+
+### Added
+- extension may be omitted when loading dataset in wildcard mode if dataset doesn't have extra parts
+
+## [1.0.0]
 
 ### Modified
 - removed deprecated `_from_` converters

--- a/examples/docs_loading_data.py
+++ b/examples/docs_loading_data.py
@@ -138,8 +138,8 @@ that match a particular pattern, e.g. `one.load_dataset(eid, '*wheel.position.np
 
 By default wildcard mode is on.  In this mode, the extension may be omitted, e.g.
 `one.load_dataset(eid, 'spikes.times')`. This is equivalent to 'spikes.times.*'. Note that an
-exception will be raised if datasets with more than one extension are found (such as 
-'spikes.times.npy' and 'spikes.times.csv').  When loading a dataset with extra parts, 
+exception will be raised if datasets with more than one extension are found (such as
+'spikes.times.npy' and 'spikes.times.csv').  When loading a dataset with extra parts,
 the extension (or wildcard) is explicitly required: 'spikes.times.part1.*'.
 
 If you set the wildcards property of One to False, loading will be done using regular expressions,

--- a/examples/docs_loading_data.py
+++ b/examples/docs_loading_data.py
@@ -129,15 +129,21 @@ print([x for x in one.list_collections(session) if 'alf/probe' in x])
 """
 Advanced loading:
 
-The load methods require an exact match, therefore `one.load_dataset(eid, 'spikes.times')` will
-raise an exception because 'spikes.times' does not exactly match 'spikes.times.npy'.
-Likewise `one.load_object(eid, 'trial')` will fail because 'trial' != 'trials'.
+The load methods typically require an exact match, therefore when loading '_ibl_wheel.position.npy'
+`one.load_dataset(eid, 'wheel.position.npy')` will raise an exception because the namespace is
+missing. Likewise `one.load_object(eid, 'trial')` will fail because 'trial' != 'trials'.
 
 Loading can be done using unix shell style wildcards, allowing you to load objects and datasets
-that match a particular pattern.
+that match a particular pattern, e.g. `one.load_dataset(eid, '*wheel.position.npy')`.
+
+By default wildcard mode is on.  In this mode, the extension may be omitted, e.g.
+`one.load_dataset(eid, 'spikes.times')`. This is equivalent to 'spikes.times.*'. Note that an
+exception will be raised if datasets with more than one extension are found (such as 
+'spikes.times.npy' and 'spikes.times.csv').  When loading a dataset with extra parts, 
+the extension (or wildcard) is explicitly required: 'spikes.times.part1.*'.
 
 If you set the wildcards property of One to False, loading will be done using regular expressions,
-allowing more powerful pattern matching.
+allowing for more powerful pattern matching.
 
 Below is table showing how to express unix style wildcards as a regular expression:
 
@@ -146,6 +152,8 @@ Below is table showing how to express unix style wildcards as a regular expressi
    .*            *          Match zero or more chars     spikes.times.*
    .?            ?          Match one char               timestamps.?sv
    []            []         Match a range of chars       obj.attr.part[0-9].npy
+
+NB: In regex '.' means 'any character'; to match '.' exactly, escape it with a backslash
 
 Examples:
     spikes.times.* (regex), spikes.times* (wildcard) matches...

--- a/one/api.py
+++ b/one/api.py
@@ -39,7 +39,7 @@ import one.webclient as wc
 import one.alf.io as alfio
 import one.alf.exceptions as alferr
 from .alf.cache import make_parquet_db
-from .alf.files import rel_path_parts, get_session_path, get_alf_path
+from .alf.files import rel_path_parts, get_session_path, get_alf_path, filename_parts
 from .alf.spec import is_uuid_string
 from one.converters import ConversionMixin
 import one.util as util
@@ -661,13 +661,19 @@ class One(ConversionMixin):
         Examples
         --------
         intervals = one.load_dataset(eid, '_ibl_trials.intervals.npy')
-        intervals = one.load_dataset(eid, '*trials.intervals*')
+        # Load dataset without specifying extension
+        intervals = one.load_dataset(eid, 'trials.intervals')  # wildcard mode only
+        intervals = one.load_dataset(eid, '*trials.intervals*')  # wildcard mode only
         filepath = one.load_dataset(eid '_ibl_trials.intervals.npy', download_only=True)
         spike_times = one.load_dataset(eid 'spikes.times.npy', collection='alf/probe01')
-        old_spikes = one.load_dataset(eid, ''spikes.times.npy',
+        old_spikes = one.load_dataset(eid, 'spikes.times.npy',
                                       collection='alf/probe01', revision='2020-08-31')
         """
         datasets = self.list_datasets(eid, details=True, query_type=query_type or self.mode)
+        # If only two parts and wildcards are on, append ext wildcard
+        if self.wildcards and isinstance(dataset, str) and len(dataset.split('.')) == 2:
+            dataset += '.*'
+            _logger.info('Appending extension wildcard: ' + dataset)
 
         datasets = util.filter_datasets(datasets, dataset, collection, revision,
                                         wildcards=self.wildcards)
@@ -761,6 +767,9 @@ class One(ConversionMixin):
             return None, all_datasets.iloc[0:0]  # Return empty
 
         # Filter and load missing
+        if self.wildcards:  # Append extension wildcard if 'object.attribute' string
+            datasets = [x + ('.*' if isinstance(x, str) and len(x.split('.')) == 2 else '')
+                        for x in datasets]
         slices = [util.filter_datasets(all_datasets, x, y, z, wildcards=self.wildcards)
                   for x, y, z in zip(datasets, collections, revisions)]
         present = [len(x) == 1 for x in slices]

--- a/one/api.py
+++ b/one/api.py
@@ -39,7 +39,7 @@ import one.webclient as wc
 import one.alf.io as alfio
 import one.alf.exceptions as alferr
 from .alf.cache import make_parquet_db
-from .alf.files import rel_path_parts, get_session_path, get_alf_path, filename_parts
+from .alf.files import rel_path_parts, get_session_path, get_alf_path
 from .alf.spec import is_uuid_string
 from one.converters import ConversionMixin
 import one.util as util

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -418,6 +418,10 @@ class TestONECache(unittest.TestCase):
         with self.assertRaises(alferr.ALFObjectNotFound):
             self.one.load_dataset(eid, '_iblrig_leftCamera.timestamps.ssv')
 
+        # Check loading without extension
+        file = self.one.load_dataset(eid, '_ibl_wheel.position', download_only=True)
+        self.assertTrue(str(file).endswith('wheel.position.npy'))
+
     def test_load_datasets(self):
         eid = 'KS005/2019-04-02/001'
         # Check download only
@@ -463,6 +467,12 @@ class TestONECache(unittest.TestCase):
         self.assertIsNone(self.one.load_datasets(eid, [])[0])
         with self.assertRaises(alferr.ALFObjectNotFound):
             self.one.load_datasets(eid, dsets, collections='none', assert_present=True)
+
+        # Check loading without extensions
+        # Check download only
+        dsets = ['_ibl_wheel.position.npy', '_ibl_wheel.timestamps']
+        files, meta = self.one.load_datasets(eid, dsets, download_only=True)
+        self.assertTrue(all(isinstance(x, Path) for x in files))
 
     def test_load_dataset_from_id(self):
         id = np.array([[-9204203870374650458, -6411285612086772563]])

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='ONE-api',
-    version='1.0.0',
+    version='1.1.0',
     python_requires='>={}.{}'.format(*REQUIRED_PYTHON),
     description='Open Neurophysiology Environment',
     license="MIT",


### PR DESCRIPTION
In `load_dataset` and `load_datasets` when in wildcard mode the extension may be omitted: `load_dataset(eid, 'spikes.times')`.  This is equivalent to `load_dataset(eid, 'spikes.times.*')`.  

Notes:
- This will not work in regex mode as the period has multiple functions, making parsing the string very difficult
- The extension or its wildcard must be provided when loading datasets with extra parts, i.e. `spikes.times.part1.ext`)