### PR TITLE
Register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Changelog
 
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [0.5.3]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.0.0]
+
+### Added
+
+- registration module with functions for posting sessions and file records to Alyx
 
 ### Modified
 
-- HOTFIX: Error no longer raised when logging dimension mismatch in alf.io.load_object
+- bumped minimum pandas version in requirements
+- REST cache supports URL with port
+- describe revision now supported
+- ALF spec now requires 'Subjects' folder in order to parse lab, i.e. .../lab/Subjects/subjects/...
+
+## [0.5.3]
+
+### Modified
+
+- HOTFIX: error no longer raised when logging dimension mismatch in alf.io.load_object
 
 ## [0.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - REST cache supports URL with port
 - describe revision now supported
 - ALF spec now requires 'Subjects' folder in order to parse lab, i.e. .../lab/Subjects/subjects/...
+- password prompt now specifies user
 
 ## [1.1.0]
 
@@ -23,7 +24,6 @@
 - removed deprecated `_from_` converters
 - removed walrus from test
 - raise warning when fails to set dataset exists to False
-- password prompt now specifies user
 
 ## [0.5.3]
 

--- a/one/alf/files.py
+++ b/one/alf/files.py
@@ -200,11 +200,11 @@ def get_alf_path(path: Union[str, Path]) -> str:
 
     Examples
     --------
-    get_alf_path('etc/etc/lab/subj/2021-01-21/001')
-    'lab/subj/2021-01-21/001/collection/file.attr.ext'
+    get_alf_path('etc/etc/lab/Subjects/subj/2021-01-21/001')
+    'lab/Subjects/subj/2021-01-21/001/collection/file.attr.ext'
 
-    get_alf_path('subj/2021-01-21/001/collection/file.attr.ext')
-    'file.attr.ext'
+    get_alf_path('etc/etc/subj/2021-01-21/001/collection/file.attr.ext')
+    'subj/2021-01-21/001/collection/file.attr.ext'
 
     get_alf_path('collection/file.attr.ext')
     'collection/file.attr.ext'

--- a/one/alf/spec.py
+++ b/one/alf/spec.py
@@ -1,8 +1,4 @@
-"""The complete AlF specification descriptors and validators
-TODO Currently extensions are not optional
-TODO Make Subjects an optional requirement with lab, i.e. lab/Subjects/subject/date/num OR
- subject/date/num but NOT lab/subject/date/num
-"""
+"""The complete AlF specification descriptors and validators"""
 import re
 import textwrap
 from uuid import UUID
@@ -11,9 +7,9 @@ from typing import Union
 from iblutil.util import flatten
 
 SPEC_DESCRIPTION = {
-    'lab': 'The name of the lab where the data were collected',
+    'lab': 'The name of the lab where the data were collected (optional).',
     'Subjects': 'An optional directory to indicate that the experiment data are divided by '
-                'subject',
+                'subject.  If organizing by lab, this directory is required.',
     'subject': 'The subject name, typically an arbitrary label',
     'date': 'The date on which the experiment session took place, in ISO format, i.e. yyyy-mm-dd',
     'number': 'The sequential session number of the day, optionally zero-padded to be three '
@@ -90,7 +86,7 @@ SPEC_DESCRIPTION = {
 
 
 """The following are the specifications and patterns for ALFs"""
-SESSION_SPEC = '{lab}/(Subjects/)?{subject}/{date}/{number}'
+SESSION_SPEC = '({lab}/Subjects/)?{subject}/{date}/{number}'
 COLLECTION_SPEC = r'({collection}/)?(#{revision}#/)?'
 FILE_SPEC = r'_?{namespace}?_?{object}\.{attribute}_?{timescale}*\.?{extra}*\.{extension}$'
 REL_PATH_SPEC = f'{COLLECTION_SPEC}{FILE_SPEC}'

--- a/one/api.py
+++ b/one/api.py
@@ -1479,6 +1479,7 @@ class OneAlyx(One):
         except requests.exceptions.HTTPError as ex:
             if '404' not in str(ex):
                 raise ex
+            print(f'revision "{revision}" not found')
 
     def _dataset_name2id(self, dset_name, eid=None):
         # TODO finish function

--- a/one/api.py
+++ b/one/api.py
@@ -1444,14 +1444,28 @@ class OneAlyx(One):
             raise ValueError('Unrecognized name or UUID')
         return self.alyx.rest('datasets', 'read', id=dset)['dataset_type']
 
-    def describe_revision(self, revision):
-        raise NotImplementedError('Requires changes to revisions endpoint')
-        rec = self.alyx.rest('revisions', 'list', name=revision)  # py 3.8
-        # if rec := self.alyx.rest('revisions', 'list', name=revision):  # py 3.8
-        if rec:
-            print(rec[0]['description'])
-        else:
-            print(f'Revision "{revision}" not found')
+    def describe_revision(self, revision, full=False):
+        """Print description of a revision
+
+        Parameters
+        ----------
+        revision : str
+            The name of the revision (without '#')
+        full : bool
+            If true, returns the matching record
+
+        Returns
+        -------
+        None if full is false or no record found, otherwise returns record as dict
+        """
+        try:
+            rec = self.alyx.rest('revisions', 'read', id=revision)
+            print(rec['description'])
+            if full:
+                return rec
+        except requests.exceptions.HTTPError as ex:
+            if '404' not in str(ex):
+                raise ex
 
     def _dataset_name2id(self, dset_name, eid=None):
         # TODO finish function

--- a/one/params.py
+++ b/one/params.py
@@ -187,7 +187,7 @@ def get_rest_dir(client=None) -> Path:
     rest_dir = get_params_dir() / '.rest'
     if client:
         scheme, loc, *_ = urlsplit(client)
-        rest_dir /= Path(loc, scheme)
+        rest_dir /= Path(loc.replace(':', '_'), scheme)
     return rest_dir
 
 

--- a/one/registration.py
+++ b/one/registration.py
@@ -1,0 +1,478 @@
+"""Session creation and datasets registration
+
+The RegistrationClient provides an high-level API for creating experimentation sessions on Alyx
+and registering associated datasets.
+
+Summary of methods
+------------------
+create_new_session - Create a new local session folder and optionally create session record on Alyx
+create_session - Create session record on Alyx from local path, without registering files
+create_sessions - Create sessions and register files for folder containing a given flag file
+register_session - Create a session on Alyx from local path and register any ALF datasets present
+register_files - Register a list of files to their respective sessions on Alyx
+"""
+import pathlib
+import uuid
+from pathlib import Path, PurePosixPath
+import datetime
+import logging
+from uuid import UUID
+import itertools
+from collections import defaultdict
+
+import requests.exceptions
+
+from iblutil.io import hashfile
+
+import one.alf.io as alfio
+from one.alf.files import session_path_parts, get_session_path
+import one.alf.exceptions as alferr
+from one.api import ONE
+from one.util import ensure_list
+
+_logger = logging.getLogger(__name__)
+
+
+class RegistrationClient:
+    """
+    Object that keeps the ONE instance and provides method to create sessions and register data.
+    """
+    def __init__(self, one=None):
+        self.one = one
+        if not one:
+            self.one = ONE(cache_rest=None)
+        self.dtypes = self.one.alyx.rest('dataset-types', 'list')
+        self.registration_patterns = [
+            dt['filename_pattern'] for dt in self.dtypes if dt['filename_pattern']]
+        self.file_extensions = [df['file_extension'] for df in
+                                self.one.alyx.rest('data-formats', 'list', no_cache=True)]
+
+    def create_sessions(self, root_data_folder, glob_pattern='**/create_me.flag', dry=False):
+        """
+        Create sessions looking recursively for flag files
+
+        Parameters
+        ----------
+        root_data_folder : str, pathlib.Path
+            Folder to look for sessions
+        glob_pattern : str
+            Register valid sessions that contain this pattern
+        dry : bool
+            If true returns list of sessions without creating them on Alyx
+
+        Returns
+        -------
+            Newly created session paths
+        """
+        flag_files = Path(root_data_folder).glob(glob_pattern)
+        for flag_file in flag_files:
+            if dry:
+                print(flag_file)
+                continue
+            _logger.info('creating session for ' + str(flag_file.parent))
+            # providing a false flag stops the registration after session creation
+            self.create_session(flag_file.parent)
+            flag_file.unlink()
+        return [ff.parent for ff in flag_files]
+
+    def create_session(self, session_path) -> dict:
+        """Create a remote session on Alyx from a local session path, without registering files
+
+        Parameters
+        ----------
+        session_path : str, pathlib.Path
+            The path ending with subject/date/number
+
+        Returns
+        -------
+        Newly created session record
+        """
+        return self.register_session(session_path, file_list=False)[0]
+
+    def create_new_session(self, subject, session_root=None, date=None, register=True):
+        """Create a new local session folder and optionally create session record on Alyx
+
+        Parameters
+        ----------
+        subject : str
+            The subject name.  Must exist on Alyx.
+        session_root : str, pathlib.Path
+            The root folder in which to create the subject/date/number folder.  Defaults to ONE
+            cache directory.
+        date : datetime.datetime, datetime.date, str
+            An optional date for the session.  If None the current time is used.
+        register : bool
+            If true, create session record on Alyx database
+
+        Returns
+        -------
+        New local session path; the experiment UUID if register is true
+
+        Examples
+        --------
+        # Create a local session only
+        session_path, _ = RegistrationClient.create_new_session('Ian', register=False)
+        # Register a session on Alyx in a specific location
+        session_path, eid = RegistrationClient.create_new_session('Ian', '/data/mylab/Subjects')
+        # Create a session for a given date
+        session_path, eid = RegistrationClient.create_new_session('Ian', date='2020-01-01')
+        """
+        assert not self.one.offline, 'ONE must be in online mode'
+        date = self.ensure_ISO8601(date)  # Format, validate
+        # Ensure subject exists on Alyx
+        self.assert_exists(subject, 'subjects')
+        session_root = Path(session_root or self.one.alyx.cache_dir) / subject / date[:10]
+        session_path = session_root / alfio.next_num_folder(session_root)
+        session_path.mkdir(exist_ok=True, parents=True)  # Ensure folder exists on disk
+        eid = UUID(self.create_session(session_path)['url'][-36:]) if register else None
+        return session_path, eid
+
+    def find_files(self, session_path):
+        """
+        Returns an generator of file names that match one of the dataset type patterns in Alyx
+
+        Parameters
+        ----------
+        session_path : str, pathlib.Path
+            The session path to search
+
+        Returns
+        -------
+        Iterable of file paths that match the dataset type patterns in Alyx
+        """
+        session_path = Path(session_path)
+        types = (x['filename_pattern'] for x in self.dtypes if x['filename_pattern'])
+        dsets = itertools.chain.from_iterable(session_path.rglob(x) for x in types)
+        return (x for x in dsets if x.is_file() and
+                any(x.name.endswith(y) for y in self.file_extensions))
+
+    def assert_exists(self, member, endpoint):
+        """Raise an error if a given member doesn't exist on Alyx database
+
+        Parameters
+        ----------
+        member : str, uuid.UUID, list
+            The member ID(s) to verify
+        endpoint: str
+            The endpoint at which to look it up
+
+        Examples
+        --------
+        client.assert_exists('ALK_036', 'subjects')
+        client.assert_exists('user_45', 'users')
+        client.assert_exists('local_server', 'repositories')
+
+        Raises
+        -------
+        one.alf.exceptions.AlyxSubjectNotFound
+            Subject does not exist on Alyx
+        one.alf.exceptions.ALFError
+            Member does not exist on Alyx
+        requests.exceptions.HTTPError
+            Failed to connect to Alyx database or endpoint not found
+        """
+        if isinstance(member, (str, uuid.UUID)):
+            try:
+                self.one.alyx.rest(endpoint, 'read', id=str(member), no_cache=True)
+            except requests.exceptions.HTTPError as ex:
+                if '404' not in str(ex):
+                    raise ex
+                elif endpoint == 'subjects':
+                    raise alferr.AlyxSubjectNotFound(member)
+                else:
+                    raise alferr.ALFError(f'Member "{member}" doesn\'t exist in Alyx')
+        else:
+            for x in member:
+                self.assert_exists(x, endpoint)
+
+    @staticmethod
+    def ensure_ISO8601(date) -> str:
+        """Ensure provided date is ISO 8601 compliant
+
+        Parameters
+        ----------
+        date : str, None, datetime.date, datetime.datetime
+            An optional date to convert to ISO string.  If None, the current datetime is used.
+
+        Returns
+        -------
+        The datetime as an ISO 8601 str
+        """
+        date = date or datetime.datetime.now()  # If None get current time
+        if isinstance(date, str):
+            date = datetime.datetime.fromisoformat(date)  # Validate by parsing
+        elif type(date) is datetime.date:
+            date = datetime.datetime.fromordinal(date.toordinal())
+        return datetime.datetime.isoformat(date)
+
+    def register_session(self, ses_path, users=None, file_list=True, **kwargs):
+        """
+        Register session in Alyx
+
+        Parameters
+        ----------
+        ses_path : str, pathlib.Path
+            The local session path
+        users : str, list
+            The user(s) to attribute to the session
+        file_list : bool, list
+            An optional list of file paths to register.  If True, all valid files within the
+            session folder are registered.  If False, no files are registered
+        location : str
+            The optional location within the lab where the experiment takes place
+        procedures : str, list
+            An optional list of procedures, e.g. 'Behavior training/tasks'
+        n_correct_trials : int
+            The number of correct trials (optional)
+        n_trials : int
+            The total number of completed trials (optional)
+        json : dict, str
+            Optional JSON data
+        project: str, list
+            The project(s) to which the experiment belongs (optional)
+        type : str
+            The experiment type, e.g. 'Experiment', 'Base'
+        task_protocol : str
+            The task protocol (optional)
+
+        Returns
+        -------
+        An Alyx session record and list of file records (or None if file_list is False)
+        """
+        if isinstance(ses_path, str):
+            ses_path = Path(ses_path)
+        details = session_path_parts(ses_path.as_posix(), as_dict=True, assert_valid=True)
+        # query alyx endpoints for subject, error if not found
+        self.assert_exists(details['subject'], 'subjects')
+
+        # look for a session from the same subject, same number on the same day
+        session_id, session = self.one.search(subject=details['subject'],
+                                              date_range=details['date'],
+                                              number=details['number'],
+                                              details=True, query_type='remote')
+        users = ensure_list(users or self.one.alyx.user)
+        self.assert_exists(users, 'users')
+
+        # if nothing found create a new session in Alyx
+        ses_ = {'subject': details['subject'],
+                'users': users,
+                'type': 'Experiment',
+                'number': details['number']}
+        if kwargs.get('end_time', False):
+            ses_['end_time'] = self.ensure_ISO8601(kwargs.pop('end_time'))
+        start_time = kwargs.pop('start_time', None)
+        if kwargs.get('procedures', False):
+            ses_['procedures'] = ensure_list(kwargs.pop('procedures'))
+        assert ('subject', 'number') not in kwargs
+        if 'lab' not in kwargs and details['lab']:
+            kwargs.update({'lab': details['lab']})
+        ses_.update(kwargs)
+
+        if not session:  # Create from scratch
+            ses_['start_time'] = self.ensure_ISO8601(start_time)
+            session = self.one.alyx.rest('sessions', 'create', data=ses_)
+        else:  # Update existing
+            if start_time:
+                ses_['start_time'] = self.ensure_ISO8601(start_time)
+            session = self.one.alyx.rest('sessions', 'update', id=session_id[0], data=ses_)
+
+        _logger.info(session['url'] + ' ')
+        # at this point the session has been created. If create only, exit
+        if not file_list:
+            return session, None
+        recs = self.register_files(self.find_files(ses_path) if file_list is True else file_list)
+        return session, recs
+
+    def register_files(self, file_list, versions=None, default=True, created_by=None,
+                       server_only=False, repository=None, dry=False, max_md5_size=None):
+        """
+        Registers a set of files belonging to a session only on the server
+
+        Parameters
+        ----------
+        file_list : list, str, pathlib.Path
+            A filepath (or list thereof) of ALF datasets to register to Alyx
+        created_by : str
+            Name of Alyx user (defaults to whoever is logged in to ONE instance)
+        repository : str
+            Name of the repository in Alyx to register to
+        server_only : bool
+            Will only create file records in the 'online' repositories and skips local repositories
+        versions : list of str
+            Optional version tags
+        default : bool
+            Whether to set as default revision (defaults to True)
+        dry : bool
+            When true returns POST data for registration endpoint without submitting the data
+        max_md5_size : int
+            Maximum file in bytes to compute md5 sum (always compute if None)
+
+        Returns
+        -------
+            A list of newly created Alyx dataset records or the registration data if dry == true
+        """
+        F = defaultdict(list)  # empty map whose keys will be session paths
+        V = defaultdict(list)  # empty map for versions
+        if isinstance(file_list, (str, pathlib.Path)):
+            file_list = [file_list]
+
+        if versions is None or isinstance(versions, str):
+            versions = itertools.repeat(versions)
+        else:
+            versions = itertools.cycle(versions)
+
+        # Filter valid files and sort by session
+        for fn, ver in zip(map(pathlib.Path, file_list), versions):
+            session_path = get_session_path(fn)
+            if fn.suffix not in self.file_extensions:
+                _logger.debug(f'{fn}: No matching extension {fn.suffix} in database')
+                continue
+            if fn.suffix not in self.file_extensions:
+                _logger.warning('No matching data format (i.e. file extension) for: ' + str(fn))
+                continue
+            F[session_path].append(fn.relative_to(session_path))
+            V[session_path].append(ver)
+
+        # For each unique session, make a separate POST request
+        records = []
+        for session_path, files in F.items():
+            # this is the generic relative path: subject/yyyy-mm-dd/NNN
+            details = session_path_parts(session_path.as_posix(), as_dict=True, assert_valid=True)
+            rel_path = PurePosixPath(details['subject'], details['date'], details['number'])
+            file_sizes = [session_path.joinpath(fn).stat().st_size for fn in files]
+            # computing the md5 can be very long, so this is an option to skip if the file is
+            # bigger than a certain threshold
+            md5s = [hashfile.md5(session_path.joinpath(fn))
+                    if (max_md5_size is None or sz < max_md5_size) else None
+                    for fn, sz in zip(files, file_sizes)]
+
+            _logger.info('Registering ' + str(files))
+
+            r_ = {'created_by': created_by or self.one.alyx.user,
+                  'path': rel_path.as_posix(),
+                  'filenames': [x.as_posix() for x in files],
+                  'hashes': md5s,
+                  'filesizes': file_sizes,
+                  'name': repository,
+                  'server_only': server_only,
+                  'default': default,
+                  'versions': V[session_path]}
+
+            # Add optional field
+            if details['lab']:
+                r_['labs'] = details['lab']
+            # If dry, store POST data, otherwise store resulting file records
+            records.append(r_ if dry else self.one.alyx.post('/register-file', data=r_))
+            # Log file names
+            _logger.info(f'ALYX REGISTERED DATA {"!DRY!" if dry else ""}: {rel_path}')
+            for p in files:
+                _logger.info(f"ALYX REGISTERED DATA: {p}")
+
+        return records[0] if len(F.keys()) == 1 else records
+
+    def register_water_administration(self, subject, volume, **kwargs):
+        """
+        Register a water administration to Alyx for a given subject
+
+        Parameters
+        ----------
+        subject : str
+            A subject nickname that exists on Alyx
+        volume : float
+            The total volume administrated in ml
+        date_time : str, datetime.datetime, datetime.date
+            The time of administration.  If None, the current time is used.
+        water_type : str
+            A water type that exists in Alyx; default is 'Water'
+        user : str
+            The user who administrated the water.  Currently logged-in user is the default.
+        session : str, UUID, pathlib.Path, dict
+            An optional experiment ID to associate
+        adlib : bool
+            If true, indicates that the subject was given water ad libitum
+
+        Returns
+        -------
+        A water administration record
+
+        Raises
+        ------
+        one.alf.exceptions.AlyxSubjectNotFound
+            Subject does not exist on Alyx
+        one.alf.exceptions.ALFError
+            User does not exist on Alyx
+        ValueError
+            date_time is not a valid ISO date time or session ID is not valid
+        requests.exceptions.HTTPError
+            Failed to connect to database, or submitted data not valid (500)
+        """
+        # Ensure subject exists
+        self.assert_exists(subject, 'subjects')
+        # Ensure user(s) exist
+        user = ensure_list(kwargs.pop('user', [])) or self.one.alyx.user
+        self.assert_exists(user, 'users')
+        # Ensure volume not zero
+        if volume == 0:
+            raise ValueError('Water volume must be greater than zero')
+        # Post water admin
+        wa_ = {
+            'subject': subject,
+            'date_time': self.ensure_ISO8601(kwargs.pop('date_time', None)),
+            'water_administered': float(f'{volume:.4g}'),  # Round to 4 s.f.
+            'water_type': kwargs.pop('water_type', 'Water'),
+            'user': user,
+            'adlib': kwargs.pop('adlib', False)
+        }
+        # Ensure session is valid; convert to eid
+        if kwargs.get('session', False):
+            wa_['session'] = self.one.to_eid(kwargs.pop('session'))
+            if not wa_['session']:
+                raise ValueError('Failed to parse session ID')
+
+        return self.one.alyx.rest('water-administrations', 'create', data=wa_)
+
+    def register_weight(self, subject, weight, date_time=None, user=None):
+        """
+        Register a subject weight to Alyx
+
+        Parameters
+        ----------
+        subject : str
+            A subject nickname that exists on Alyx
+        weight : float
+            The subject weight in grams
+        date_time : str, datetime.datetime, datetime.date
+            The time of weighing.  If None, the current time is used.
+        user : str
+            The user who performed the weighing.  Currently logged-in user is the default.
+
+        Returns
+        -------
+        An Alyx weight record
+
+        Raises
+        ------
+        one.alf.exceptions.AlyxSubjectNotFound
+            Subject does not exist on Alyx
+        one.alf.exceptions.ALFError
+            User does not exist on Alyx
+        ValueError
+            date_time is not a valid ISO date time or weight < 1e-4
+        requests.exceptions.HTTPError
+            Failed to connect to database, or submitted data not valid (500)
+        """
+        # Ensure subject exists
+        self.assert_exists(subject, 'subjects')
+        # Ensure user(s) exist
+        user = user or self.one.alyx.user
+        self.assert_exists(user, 'users')
+        # Ensure weight not zero
+        if weight == 0:
+            raise ValueError('Water volume must be greater than 0')
+
+        # Post water admin
+        wei_ = {'subject': subject,
+                'date_time': self.ensure_ISO8601(date_time),
+                'weight': float(f'{weight:.4g}'),  # Round to 4 s.f.
+                'user': user}
+        return self.one.alyx.rest('weighings', 'create', data=wei_)

--- a/one/tests/alf/test_alf_spec.py
+++ b/one/tests/alf/test_alf_spec.py
@@ -11,7 +11,7 @@ class TestALFSpec(unittest.TestCase):
     def test_regex(self):
         # Should return the full regex with named capture groups by default
         verifiable = alf_spec.regex()
-        expected = ('(?P<lab>\\w+)/(Subjects/)?'
+        expected = ('((?P<lab>\\w+)/Subjects/)?'
                     '(?P<subject>[\\w-]+)/(?P<date>\\d{4}-\\d{2}-\\d{2})/(?P<number>\\d{1,3})/'
                     '((?P<collection>[\\w/]+)/)?(#(?P<revision>[\\w-]+)#/)?'
                     '_?(?P<namespace>(?<=_)[a-zA-Z0-9]+)?_?(?P<object>\\w+)\\.'
@@ -108,10 +108,9 @@ class TestALFSpec(unittest.TestCase):
 
         # Test a full path with no collection, no Subjects and no number padding
         full = (
-            'angelakilab/NYU-40/2021-04-12/1/'
-            '_kilosort_raw.output.e8c9d765764778b7ee5bda08c982037f8f07e690.tar'
+            'NYU-40/2021-04-12/1/_kilosort_raw.output.e8c9d765764778b7ee5bda08c982037f8f07e690.tar'
         )
-        expected.update(collection=None, number='1')
+        expected.update(collection=None, number='1', lab=None)
         verifiable = re.match(alf_spec.regex(), full).groupdict()
         self.assertCountEqual(verifiable, expected)
 

--- a/one/tests/fixtures/rest_responses/961e5c585b4b878964a8c167fb7886445379001e
+++ b/one/tests/fixtures/rest_responses/961e5c585b4b878964a8c167fb7886445379001e
@@ -1,0 +1,1 @@
+[{"id": "9b337861-0004-4614-9b64-8f2b8dfbdeeb", "json": null, "name": "2020-01-01", "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "created_datetime": "2021-08-17T09:05:34.543630"}, "2021-08-18T11:31:00.271319"]

--- a/one/tests/fixtures/rest_responses/961e5c585b4b878964a8c167fb7886445379001e
+++ b/one/tests/fixtures/rest_responses/961e5c585b4b878964a8c167fb7886445379001e
@@ -1,1 +1,0 @@
-[{"id": "9b337861-0004-4614-9b64-8f2b8dfbdeeb", "json": null, "name": "2020-01-01", "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "created_datetime": "2021-08-17T09:05:34.543630"}, "2021-08-18T11:31:00.271319"]

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -679,15 +679,15 @@ class TestOneAlyx(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.one.pid2eid(pid, query_type='local')
 
-    @unittest.skip('Requires changes to Alyx')
     @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
     def test_describe_revision(self, mock_stdout):
         record = {
-            'name': 'ks2.1',
-            'description': 'Spike data sorted using Kilosort version 2.1\n'
+            'name': '2020-01-01',
+            'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
         }
-        self.one.describe_revision(record['name'])
-        self.assertEqual(mock_stdout.getvalue(), record['description'])
+        with mock.patch('one.params.iopar.getfile', new=partial(util.get_file, self.tempdir.name)):
+            self.one.describe_revision(record['name'])
+        self.assertEqual(record['description'], mock_stdout.getvalue().strip())
         self.one.describe_revision('foobar')
         self.assertTrue('not found' in mock_stdout.getvalue())
 

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -19,11 +19,12 @@ from one.tests import util
 class TestRegistrationClient(unittest.TestCase):
     one = None
     subject = None
+    temp_dir = None
 
     @classmethod
     def setUpClass(cls) -> None:
         temp_dir = util.set_up_env()
-        cls.addClassCleanup(temp_dir.cleanup)
+        # cls.addClassCleanup(temp_dir.cleanup)  # py3.8
         cls.one = ONE(**TEST_DB_1, cache_dir=temp_dir.name)
         cls.subject = ''.join(random.choices(string.ascii_letters, k=10))
         cls.one.alyx.rest('subjects', 'create', data={'lab': 'mainenlab', 'nickname': cls.subject})

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -25,10 +25,8 @@ class TestRegistrationClient(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        temp_dir = util.set_up_env(use_temp_cache=False)
-        if parse_version('.'.join(map(str, version_info[:2]))) >= parse_version('3.8'):
-            cls.addClassCleanup(temp_dir.cleanup)  # py3.8
-        cls.one = ONE(**TEST_DB_1, cache_dir=temp_dir.name)
+        cls.temp_dir = util.set_up_env(use_temp_cache=False)
+        cls.one = ONE(**TEST_DB_1, cache_dir=cls.temp_dir.name)
         cls.subject = ''.join(random.choices(string.ascii_letters, k=10))
         cls.one.alyx.rest('subjects', 'create', data={'lab': 'mainenlab', 'nickname': cls.subject})
         # Create some files for this subject
@@ -185,6 +183,7 @@ class TestRegistrationClient(unittest.TestCase):
         for ses in cls.one.alyx.rest('sessions', 'list', subject=cls.subject, no_cache=True):
             cls.one.alyx.rest('sessions', 'delete', id=ses['url'][-36:])
         cls.one.alyx.rest('subjects', 'delete', id=cls.subject)
+        cls.temp_dir.cleanup()
 
 
 if __name__ == '__main__':

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -96,7 +96,7 @@ class TestRegistrationClient(unittest.TestCase):
                     for x in self.client.dtypes)
         removed = self.client.dtypes.pop(next(i for i, x in enumerate(existing) if x))
         files = list(self.client.find_files(self.session_path))
-        self.assertEqual(105, len(files))
+        self.assertEqual(4, len(files))
         self.assertTrue(all(x.is_file() for x in files))
         # Check removed file pattern not in file list
         self.assertFalse(fnmatch.filter([x.name for x in files], removed['filename_pattern']))
@@ -150,7 +150,7 @@ class TestRegistrationClient(unittest.TestCase):
         # Test a few things not checked in register_session
         session_path, eid = self.client.create_new_session(self.subject)
         # Check registering single file, dry run, default False
-        file_name = session_path.joinpath('spikes.times.npy')
+        file_name = session_path.joinpath('wheel.position.npy')
         file_name.touch()
         rec = self.client.register_files(str(file_name), default=False, dry=True)
         self.assertIsInstance(rec, dict)
@@ -161,14 +161,14 @@ class TestRegistrationClient(unittest.TestCase):
         self.client.dtypes[-1]['name'] += '1'
         # Try registering ambiguous / invalid datasets
         ambiguous = self.client.dtypes[-1]['filename_pattern'].replace('*', 'npy')
-        files = [session_path.joinpath('spikes.times.xxx'),  # Unknown ext
+        files = [session_path.joinpath('wheel.position.xxx'),  # Unknown ext
                  session_path.joinpath('foo.bar.npy'),  # Unknown dtype
                  session_path.joinpath(ambiguous)  # Ambiguous dtype
                  ]
         version = ['1.2.9'] * len(files)
         with self.assertLogs('one.registration', logging.DEBUG) as dbg:
             rec = self.client.register_files(files, versions=version)
-            self.assertIn('spikes.times.xxx: No matching extension', dbg.records[0].message)
+            self.assertIn('wheel.position.xxx: No matching extension', dbg.records[0].message)
             self.assertIn('foo.bar.npy: No matching dataset type', dbg.records[1].message)
             self.assertIn(f'{ambiguous}: Multiple matching', dbg.records[2].message)
         self.assertFalse(len(rec))

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -6,8 +6,6 @@ import random
 import datetime
 import fnmatch
 from io import StringIO
-from sys import version_info  # For 3.7
-from pkg_resources import parse_version
 
 from one.api import ONE
 from one import registration

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -11,9 +11,15 @@ from iblutil.io.parquet import uuid2np, np2str
 import one.params
 
 
-def set_up_env() -> tempfile.TemporaryDirectory:
+def set_up_env(use_temp_cache=True) -> tempfile.TemporaryDirectory:
     """
     Create a temporary directory and copy cache fixtures over
+
+    Parameters
+    ----------
+    use_temp_cache : str
+        If True, copies REST cache fixtures to the temporary directory, otherwise they are copied
+        to the directory returned by one.params.get_params_dir
 
     Returns
     -------
@@ -27,7 +33,8 @@ def set_up_env() -> tempfile.TemporaryDirectory:
         assert Path(filename).exists()
 
     # Copy cached rest responses
-    setup_rest_cache(Path(tempdir.name) / '.one')
+    rest_cache_location = Path(tempdir.name) / '.one' if use_temp_cache else None
+    setup_rest_cache(rest_cache_location)
 
     return tempdir
 

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -17,7 +17,7 @@ def set_up_env(use_temp_cache=True) -> tempfile.TemporaryDirectory:
 
     Parameters
     ----------
-    use_temp_cache : str
+    use_temp_cache : bool
         If True, copies REST cache fixtures to the temporary directory, otherwise they are copied
         to the directory returned by one.params.get_params_dir
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flake8>=3.7.8
 numpy>=1.18
-pandas>=0.24.2
+pandas>=1.2.4
 tqdm>=4.32.1
 requests>=2.22.0
 iblutil


### PR DESCRIPTION
### Added

- registration module with functions for posting sessions and file records to Alyx

### Modified

- bumped minimum pandas version in requirements
- REST cache supports URL with port
- describe revision now supported
- ALF spec now requires 'Subjects' folder in order to parse lab, i.e. .../lab/Subjects/subjects/...
- password prompt now specifies user
