### PR TITLE
makes sure the error message includes all json fields

### DIFF
--- a/one/webclient.py
+++ b/one/webclient.py
@@ -543,7 +543,7 @@ class AlyxClient():
             return
         else:
             try:
-                message = json.loads(r.text).get('detail')
+                message = json.loads(r.text)
             except json.decoder.JSONDecodeError:
                 message = r.text
             raise requests.HTTPError(r.status_code, rest_query, message, response=r)


### PR DESCRIPTION
I've noticed that by getting only the `details` field, many error messages were overlooked while they are super important when working with REST endpoints.