### PR TITLE
Update FAQ; version var; check min api version; lazy auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 # Changelog
 ## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.8.0]
 
+### Added
+
+- added `from_df` method to one.alf.io.AlfBunch
+- added `__version__` variable
+- added check for remote cache minimum API version
+- user prompted to verify settings correct in setup
+
 ### Modified
 
 - datasets cache table expected to have index of (eid, id).  NB: This changes the order of datasets returned by some functions
 - multithreading moved from One._download_datasets to one.webclient.http_download_file_list
 - cache_dir kwarg renamed to target_dir in one.webclient.http_download_file
 - 'table' attribute now split into columns and merged
-- added `from_df` method to one.alf.io.AlfBunch
+- when no username or password provided to constructor, AlyxClient init doesn't call authenticate
+- 'stay_logged_in' kwarg removed from AlyxClient constructor; must manually call `authenticate` or remember to call `logout`
+- user prompted whether to make url default in setup even if default already set
 
 ## [1.7.1]
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -56,3 +56,34 @@ called.  To avoid this, run the following command instead:
 from one.api import OneAlyx
 new_one = OneAlyx.setup(base_url='https://alyx.example.com')
 ```
+
+## How do I change my download (a.k.a. cache) directory?
+For one-time changes, simply re-run the setup routine:
+```python
+from one.api import ONE
+new_one = ONE().setup()  # Re-run setup for default database
+```
+When prompted ('Enter the location of the download cache') enter the absolute path of the new download location.
+
+## How do check who I'm logged in as?
+```python
+from one.api import ONE
+one = ONE()
+if not one.offline:
+    print(one.alyx.user)
+    print(one.alyx.base_url)
+```
+
+## How do I log out, or temporarily log in as someone else?
+To log out:
+```python
+from one.api import ONE
+one = ONE()
+
+one.alyx.logout()
+```
+
+To log in as someone else temporarily:
+```python
+one.alyx.authenticate(username='other_user', cache_token=False, force=True)
+```

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,1 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
+__version__ = '1.8.0'

--- a/one/params.py
+++ b/one/params.py
@@ -161,9 +161,15 @@ def setup(client=None, silent=False, make_default=None):
                 break
             cache_dir = input(prompt) or cache_dir  # Prompt for another directory
 
-        if make_default is None and 'DEFAULT' not in cache_map.as_dict():
+        if make_default is None:
             answer = input('Would you like to set this URL as the default one? [Y/n]')
-            make_default = True if not answer or answer[0].lower() == 'y' else False
+            make_default = (answer or 'y')[0].lower() == 'y'
+
+        # Verify setup pars
+        answer = input('Are the above settings correct? [Y/n]')
+        if answer and answer.lower()[0] == 'n':
+            print('SETUP ABANDONED.  Please re-run.')
+            return par_current
     else:
         par = par_current
 

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -936,6 +936,13 @@ class TestOneAlyx(unittest.TestCase):
                     self.one._load_cache(clobber=True)
                     self.assertEqual('local', self.one.mode)
                 self.assertTrue('Failed to connect' in lg.output[-1])
+
+            cache_info = {'min_api_version': '200.0.0'}
+            # Check version verification
+            with mock.patch.object(self.one.alyx, 'get', return_value=cache_info),\
+                    self.assertWarns(UserWarning):
+                self.one._load_cache(clobber=True)
+
         finally:  # Restore properties
             self.one.mode = 'auto'
             self.one.alyx.silent = True

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -471,7 +471,7 @@ class AlyxClient():
     base_url = None
 
     def __init__(self, base_url=None, username=None, password=None,
-                 cache_dir=None, silent=False, cache_rest='GET', stay_logged_in=True):
+                 cache_dir=None, silent=False, cache_rest='GET'):
         """
         Create a client instance that allows to GET and POST to the Alyx server.
         For One, constructor attempts to authenticate with credentials in params.py.
@@ -498,10 +498,11 @@ class AlyxClient():
         self._par = one.params.get(client=base_url, silent=self.silent)
         self.base_url = base_url or self._par.ALYX_URL
         self._par = self._par.set('CACHE_DIR', cache_dir or self._par.CACHE_DIR)
-        self.authenticate(username, password, cache_token=stay_logged_in)
+        if username or password:
+            self.authenticate(username, password)
         self._rest_schemes = None
         # the mixed accept application may cause errors sometimes, only necessary for the docs
-        self._headers['Accept'] = 'application/json'
+        self._headers = {**(self._headers or {}), 'Accept': 'application/json'}
         # REST cache parameters
         # The default length of time that cache file is valid for,
         # The default expiry is overridden by the `expires` kwarg.  If False, the caching is

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=1.2.4
 tqdm>=4.32.1
 requests>=2.22.0
 iblutil
+packaging

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,20 @@ with open('README.md', 'r') as f:
 with open('requirements.txt') as f:
     require = [x.strip() for x in f.readlines() if not x.startswith('git+')]
 
+
+def get_version(rel_path):
+    here = Path(__file__).parent.absolute()
+    with open(here.joinpath(rel_path), 'r') as fp:
+        for line in fp.read().splitlines():
+            if line.startswith('__version__'):
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
+    raise RuntimeError('Unable to find version string.')
+
+
 setup(
     name='ONE-api',
-    version='1.8.0',
+    version=get_version(Path('one', '__init__.py')),
     python_requires='>={}.{}'.format(*REQUIRED_PYTHON),
     description='Open Neurophysiology Environment',
     license="MIT",


### PR DESCRIPTION
- As long as username or password not provided to ONE, authentication is delayed until first request
- Added info on logging out and changing cache dir in FAQ
- Added __version__ variable in one.__init.py
- Check for compatible cache tables before download