### PR TITLE
dependency fix for numba

### DIFF
--- a/one/api.py
+++ b/one/api.py
@@ -1685,8 +1685,13 @@ class OneAlyx(One):
                 json_field = {'mismatch_hash': True}
             else:
                 json_field.update({'mismatch_hash': True})
-            self.alyx.rest('files', 'partial_update',
-                           id=fr[0]['url'][-36:], data={'json': json_field})
+            try:
+                self.alyx.rest('files', 'partial_update',
+                               id=fr[0]['url'][-36:], data={'json': json_field})
+            except requests.exceptions.HTTPError as ex:
+                warnings.warn(
+                    f'Failed to tag remote file record mismatch: {ex}\n'
+                    'Please contact the database administrator.')
 
     def _download_file(self, url, target_dir, keep_uuid=False, file_size=None, hash=None):
         """

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -425,14 +425,16 @@ class TestDownloadHTTP(unittest.TestCase):
 
         # Test 1: empty dir, dict mode
         dset = ac_open.get('/datasets/' + self.test_data_uuid)
-        url = wc.dataset_record_to_url(dset)
+        urls = wc.dataset_record_to_url(dset)
+        url = [u for u in urls if u.startswith('https://ibl.flatiron')]
         file_name, = ac_open.download_file(url, target_dir=cache_dir)
         self.assertTrue(os.path.isfile(file_name))
         os.unlink(file_name)
 
         # Test 2: empty dir, list mode
         dset = ac_open.get('/datasets?id=' + self.test_data_uuid)
-        url = wc.dataset_record_to_url(dset)
+        urls = wc.dataset_record_to_url(dset)
+        url = [u for u in urls if u.startswith('https://ibl.flatiron')]
         file_name, = ac_open.download_file(url, target_dir=cache_dir)
         self.assertTrue(os.path.isfile(file_name))
         os.unlink(file_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flake8>=3.7.8
-numpy>=1.18
+numpy>=1.18,<1.22
 pandas>=1.2.4
 tqdm>=4.32.1
 requests>=2.22.0


### PR DESCRIPTION
During alyx docker builds, we get the following error - numba 0.55.1 has requirement numpy<1.22,>=1.18, but you'll have numpy 1.22.3 which is incompatible.

Numba requirements - https://pypi.org/project/numba/