### PR TITLE
Cache location; urllib error catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.9.1]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.10.0]
+
+### Modified
+
+- Cache may be downloaded from a variable location set by the 'location' field returned by cache/info endpoint
+- urllib exception now caught in OneAlyx._load_cache
+
+## [1.9.1]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - cache may be downloaded from a variable location set by the 'location' field returned by cache/info endpoint
 - urllib exception now caught in OneAlyx._load_cache
 - details dict in remote mode search now contains 'date' field
+- fix tests relying on OpenAlyx
+- warning instead of error raised when tag_mismatched_dataset REST query returns 403
 
 ## [1.9.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 
 ### Modified
 
-- Cache may be downloaded from a variable location set by the 'location' field returned by cache/info endpoint
+- cache may be downloaded from a variable location set by the 'location' field returned by cache/info endpoint
 - urllib exception now caught in OneAlyx._load_cache
+- details dict in remote mode search now contains 'date' field
 
 ## [1.9.1]
 
 ### Added
 
-- Tests for OneAlyx._download_aws
+- tests for OneAlyx._download_aws
 
 ### Modified
 
@@ -20,11 +21,11 @@
 
 ### Added
 
-- Method for recording and save the UUIDs of loaded datasets
+- method for recording and save the UUIDs of loaded datasets
 
 ### Modified
 
-- Fix order of records returned by One.load_datasets when datasets missing
+- fix order of records returned by One.load_datasets when datasets missing
 
 ## [1.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - details dict in remote mode search now contains 'date' field
 - fix tests relying on OpenAlyx
 - warning instead of error raised when tag_mismatched_dataset REST query returns 403
+- list_datasets and ses2records now better handle sessions with no datasets in remote mode
 
 ## [1.9.1]
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.9.1'
+__version__ = '1.10.0'

--- a/one/api.py
+++ b/one/api.py
@@ -1303,10 +1303,10 @@ class OneAlyx(One):
 
             # Download the remote cache files
             _logger.info('Downloading remote caches...')
-            files = self.alyx.download_cache_tables()
+            files = self.alyx.download_cache_tables(cache_info.get('location'))
             assert any(files)
             super(OneAlyx, self)._load_cache(self.cache_dir)  # Reload cache after download
-        except requests.exceptions.HTTPError:
+        except (requests.exceptions.HTTPError, wc.HTTPError):
             _logger.error('Failed to load the remote cache file')
             self.mode = 'remote'
         except (ConnectionError, requests.exceptions.ConnectionError):

--- a/one/api.py
+++ b/one/api.py
@@ -1690,8 +1690,13 @@ class OneAlyx(One):
                 json_field = {'mismatch_hash': True}
             else:
                 json_field.update({'mismatch_hash': True})
-            self.alyx.rest('files', 'partial_update',
-                           id=fr[0]['url'][-36:], data={'json': json_field})
+            try:
+                self.alyx.rest('files', 'partial_update',
+                               id=fr[0]['url'][-36:], data={'json': json_field})
+            except requests.exceptions.HTTPError as ex:
+                warnings.warn(
+                    f'Failed to tag remote file record mismatch: {ex}\n'
+                    'Please contact the database administrator.')
 
     def _download_file(self, url, target_dir, keep_uuid=False, file_size=None, hash=None):
         """

--- a/one/api.py
+++ b/one/api.py
@@ -1386,8 +1386,10 @@ class OneAlyx(One):
             return super().list_datasets(eid, details=details, query_type=query_type, **filters)
         eid = self.to_eid(eid)  # Ensure we have a UUID str list
         if not eid:
-            return self._cache['datasets'].iloc[0:0]  # Return empty
+            return self._cache['datasets'].iloc[0:0] if details else []  # Return empty
         _, datasets = util.ses2records(self.alyx.rest('sessions', 'read', id=eid))
+        if datasets is None or datasets.empty:
+            return self._cache['datasets'].iloc[0:0] if details else []  # Return empty
         datasets = util.filter_datasets(
             datasets, assert_unique=False, wildcards=self.wildcards, **filters)
         # Return only the relative path

--- a/one/api.py
+++ b/one/api.py
@@ -1506,6 +1506,9 @@ class OneAlyx(One):
 
         # Make GET request
         ses = self.alyx.rest(self._search_endpoint, 'list', **params)
+        # Add date field for compatibility with One.search output
+        for s in ses:
+            s['date'] = str(datetime.fromisoformat(s['start_time']).date())
         # LazyId only transforms records when indexed
         eids = util.LazyId(ses)
         return (eids, ses) if details else eids

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -425,14 +425,16 @@ class TestDownloadHTTP(unittest.TestCase):
 
         # Test 1: empty dir, dict mode
         dset = ac_open.get('/datasets/' + self.test_data_uuid)
-        url = wc.dataset_record_to_url(dset)
+        urls = wc.dataset_record_to_url(dset)
+        url = [u for u in urls if u.startswith('https://ibl.flatiron')]
         file_name, = ac_open.download_file(url, target_dir=cache_dir)
         self.assertTrue(os.path.isfile(file_name))
         os.unlink(file_name)
 
         # Test 2: empty dir, list mode
         dset = ac_open.get('/datasets?id=' + self.test_data_uuid)
-        url = wc.dataset_record_to_url(dset)
+        urls = wc.dataset_record_to_url(dset)
+        url = [u for u in urls if u.startswith('https://ibl.flatiron')]
         file_name, = ac_open.download_file(url, target_dir=cache_dir)
         self.assertTrue(os.path.isfile(file_name))
         os.unlink(file_name)

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -867,6 +867,11 @@ class TestOneAlyx(unittest.TestCase):
         self.assertEqual(session.name, (-7544566139326771059, -2928913016589240914))
         self.assertEqual(tuple(datasets.index.names), ('eid_0', 'eid_1', 'id_0', 'id_1'))
 
+        # Check behaviour when no datasets present
+        ses['data_dataset_session_related'] = []
+        _, datasets = ses2records(ses)
+        self.assertIsNone(datasets)
+
     def test_datasets2records(self):
         """Test one.util.datasets2records"""
         eid = '8dd0fcb0-1151-4c97-ae35-2e2421695ad7'

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1110,6 +1110,9 @@ class TestOneRemote(unittest.TestCase):
         eids, det = self.one.search(subject='SWC_043', query_type='remote', details=True)
         correct = len(det) == len(eids) and 'url' in det[0] and det[0]['url'].endswith(eids[0])
         self.assertTrue(correct)
+        # Check minimum set of keys present (these are present in One.search output)
+        expected = {'lab', 'subject', 'date', 'number', 'project'}
+        self.assertTrue(det[0].keys() >= expected)
         # Test dataset search with Django
         eids = self.one.search(subject='SWC_043', dataset=['spikes.times'],
                                django='data_dataset_session_related__collection__iexact,alf',

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1087,7 +1087,7 @@ class TestOneRemote(unittest.TestCase):
         self.one._cache['datasets'] = self.one._cache['datasets'].iloc[0:0].copy()
 
         dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
-        self.assertEqual(110, len(dsets))
+        self.assertEqual(122, len(dsets))
 
         # Test empty
         dsets = self.one.list_datasets('FMR019/2021-03-18/002', details=True, query_type='remote')
@@ -1097,12 +1097,12 @@ class TestOneRemote(unittest.TestCase):
         # Test details=False, with eid
         dsets = self.one.list_datasets(self.eid, details=False, query_type='remote')
         self.assertIsInstance(dsets, list)
-        self.assertEqual(110, len(dsets))
+        self.assertEqual(122, len(dsets))
 
         # Test with other filters
         dsets = self.one.list_datasets(self.eid, collection='*probe*', filename='*channels*',
                                        details=False, query_type='remote')
-        self.assertEqual(5, len(dsets))
+        self.assertEqual(11, len(dsets))
         self.assertTrue(all(x in y for x in ('probe', 'channels') for y in dsets))
 
         with self.assertWarns(Warning):
@@ -1111,7 +1111,7 @@ class TestOneRemote(unittest.TestCase):
     def test_search(self):
         """Test OneAlyx.search"""
         eids = self.one.search(subject='SWC_043', query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        self.assertIn(self.eid, list(eids))
         eids, det = self.one.search(subject='SWC_043', query_type='remote', details=True)
         correct = len(det) == len(eids) and 'url' in det[0] and det[0]['url'].endswith(eids[0])
         self.assertTrue(correct)
@@ -1135,20 +1135,20 @@ class TestOneRemote(unittest.TestCase):
         self.assertTrue(all(len(x) == 36 for x in eids))
         # Test laboratory kwarg
         eids = self.one.search(laboratory='hoferlab', query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        self.assertIn(self.eid, list(eids))
         eids = self.one.search(lab='hoferlab', query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        self.assertIn(self.eid, list(eids))
 
     def test_load_dataset(self):
         """Test OneAlyx.load_dataset"""
-        file = self.one.load_dataset(self.eid, '_iblrig_encoderEvents.raw.ssv',
-                                     collection='raw_passive_data', query_type='remote',
+        file = self.one.load_dataset(self.eid, '_spikeglx_sync.channels.npy',
+                                     collection='raw_ephys_data', query_type='remote',
                                      download_only=True)
         self.assertIsInstance(file, Path)
-        self.assertTrue(file.as_posix().endswith('raw_passive_data/_iblrig_encoderEvents.raw.ssv'))
+        self.assertTrue(file.as_posix().endswith('raw_ephys_data/_spikeglx_sync.channels.npy'))
         # Test validations
         with self.assertRaises(alferr.ALFMultipleCollectionsFound):
-            self.one.load_dataset(self.eid, '_iblrig_encoderEvents.raw.ssv', query_type='remote')
+            self.one.load_dataset(self.eid, 'spikes.clusters', query_type='remote')
         with self.assertRaises(alferr.ALFMultipleObjectsFound):
             self.one.load_dataset(self.eid, '_iblrig_*Camera.GPIO.bin', query_type='remote')
         with self.assertRaises(alferr.ALFObjectNotFound):
@@ -1162,7 +1162,7 @@ class TestOneRemote(unittest.TestCase):
                                      download_only=True)
         self.assertIsInstance(files[0], Path)
         self.assertTrue(
-            files[0].as_posix().endswith('SWC_043/2020-09-21/001/alf/_ibl_wheel.timestamps.npy')
+            files[0].as_posix().endswith('SWC_043/2020-09-21/001/alf/_ibl_wheel.position.npy')
         )
 
     def test_get_details(self):
@@ -1215,13 +1215,21 @@ class TestOneDownload(unittest.TestCase):
         # Check behaviour when hash mismatch
         self.one.alyx.silent = False  # So we can check for warning
         file_hash = rec['hash'].replace('a', 'd')
-        with self.assertLogs(logging.getLogger('one.api'), logging.DEBUG):
+        # Check three things:
+        # 1. The mismatch should be logged at the debug level
+        # 2. As we don't have permission to update this db we should see a failure warning
+        with self.assertLogs(logging.getLogger('one.api'), logging.DEBUG), \
+                self.assertWarns(Warning, msg=f'files/{self.fid}'):
             self.one._download_dataset(rec, hash=file_hash)
+        self.one.alyx.silent = True  # Remove console clutter
 
         # Check JSON field added
-        json_field = self.one.alyx.rest('files', 'read', id=self.fid, no_cache=True)['json']
-        self.assertTrue(json_field.get('mismatch_hash', False))
-        self.one.alyx.silent = True  # Remove console clutter
+        # 3. The files endpoint should be called with a 'mismatch_hash' json key
+        fr = [{'url': f'files/{self.fid}', 'json': None}]
+        with mock.patch.object(self.one.alyx, '_generic_request', return_value=fr) as patched:
+            self.one._download_dataset(rec, hash=file_hash)
+            args, kwargs = patched.call_args_list[-1]
+            self.assertEqual(kwargs.get('data', {}), {'json': {'mismatch_hash': True}})
 
         # Check keep_uuid kwarg
         file = self.one._download_dataset(rec, keep_uuid=True)
@@ -1240,7 +1248,8 @@ class TestOneDownload(unittest.TestCase):
         # Check behaviour when URL invalid
         did = rec['url'].split('/')[-1]
         self.assertTrue(self.one._cache.datasets.loc[(slice(None), did), 'exists'].all())
-        rec['file_records'][0]['data_url'] = None
+        for fr in rec['file_records']:
+            fr['data_url'] = None
         file = self.one._download_dataset(rec)
         self.assertIsNone(file)
         self.assertFalse(self.one._cache.datasets.loc[(slice(None), did), 'exists'].all())
@@ -1257,7 +1266,7 @@ class TestOneDownload(unittest.TestCase):
             self.assertIsNone(file)
 
         rec = self.one.list_datasets(self.eid, details=True)
-        rec = rec[rec.rel_path.str.contains('channels.brainLocation')]
+        rec = rec[rec.rel_path.str.contains('pykilosort/channels.brainLocation')]
         files = self.one._download_datasets(rec)
         self.assertFalse(None in files)
 
@@ -1292,7 +1301,12 @@ class TestOneDownload(unittest.TestCase):
         mk.assert_called_with('files', 'partial_update', id=did, data={'json': data[0]['json']})
 
     def tearDown(self) -> None:
-        self.one.alyx.rest('files', 'partial_update', id=self.fid, data={'json': None})
+        try:
+            # In case we did indeed have remote REST permissions, try resetting the json field
+            self.one.alyx.rest('files', 'partial_update', id=self.fid, data={'json': None})
+        except HTTPError as ex:
+            if ex.errno != 403:
+                raise ex
         self.patch.stop()
         self.tempdir.cleanup()
 

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1089,10 +1089,16 @@ class TestOneRemote(unittest.TestCase):
         dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
         self.assertEqual(122, len(dsets))
 
-        # Test empty
+        # Test missing eid
         dsets = self.one.list_datasets('FMR019/2021-03-18/002', details=True, query_type='remote')
         self.assertIsInstance(dsets, pd.DataFrame)
         self.assertEqual(len(dsets), 0)
+
+        # Test empty datasets
+        with mock.patch('one.util.ses2records', return_value=({}, None)):
+            dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
+            self.assertIsInstance(dsets, pd.DataFrame)
+            self.assertEqual(len(dsets), 0)
 
         # Test details=False, with eid
         dsets = self.one.list_datasets(self.eid, details=False, query_type='remote')

--- a/one/util.py
+++ b/one/util.py
@@ -69,6 +69,8 @@ def ses2records(ses: dict, int_id=False):
         rec['default_revision'] = d['default_revision'] == 'True'
         return rec
 
+    if not ses.get('data_dataset_session_related'):
+        return session, None
     records = map(_to_record, ses['data_dataset_session_related'])
     index = ['eid_0', 'eid_1', 'id_0', 'id_1'] if int_id else ['eid', 'id']
     datasets = pd.DataFrame(records).set_index(index).sort_index()

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -728,7 +728,7 @@ class AlyxClient():
             raise ex
         return files
 
-    def download_cache_tables(self):
+    def download_cache_tables(self, location=None):
         """Downloads the Alyx cache tables to the local data cache directory
 
         Returns
@@ -739,9 +739,11 @@ class AlyxClient():
         self.cache_dir.mkdir(exist_ok=True)
         if not self.is_logged_in:
             self.authenticate()
+        location = location or f'{self.base_url}/cache.zip'
+        headers = self._headers if location.startswith(self.base_url) else None
         with tempfile.TemporaryDirectory(dir=self.cache_dir) as tmp:
-            file = http_download_file(f'{self.base_url}/cache.zip',
-                                      headers=self._headers,
+            file = http_download_file(location,
+                                      headers=headers,
                                       silent=self.silent,
                                       target_dir=tmp,
                                       clobber=True)


### PR DESCRIPTION
## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.10.0]

### Modified

- cache may be downloaded from a variable location set by the 'location' field returned by cache/info endpoint
- urllib exception now caught in OneAlyx._load_cache
- details dict in remote mode search now contains 'date' field
- fix tests relying on OpenAlyx
- warning instead of error raised when tag_mismatched_dataset REST query returns 403
- list_datasets and ses2records now better handle sessions with no datasets in remote mode