### PR TITLE
More robust dimension checks for ALFBunches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Modified
 
 - added clarification for generating cache with an Alyx database in documentation
+- fix'd dimension check for DataFrame attributes in ALF objects
+- dimension warning logged when dimensions don't match after appending to ALFBunch
 
 ## [1.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added clarification for generating cache with an Alyx database in documentation
 - fix'd dimension check for DataFrame attributes in ALF objects
 - dimension warning logged when dimensions don't match after appending to ALFBunch
+- created_time now updated correctly in cache meta
 
 ## [1.11.0]
 

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -73,6 +73,12 @@ class TestAlfBunch(unittest.TestCase):
         a.append(b, inplace=True)
         self.assertTrue(np.all(np.equal(c['toto'], a['toto'])))
         self.assertTrue(np.all(np.equal(c['titi'], a['titi'])))
+        # test warning thrown when uneven append occurs
+        with self.assertLogs('one.alf.io', logging.WARNING):
+            a.append({
+                'titi': np.random.rand(10),
+                'toto': np.random.rand(4)
+            })
 
     def test_append_list(self):
         # test with lists


### PR DESCRIPTION
- fix'd dimension check for DataFrame attributes in ALF objects
- dimension warning logged when dimensions don't match after appending to ALFBunch