### PR TITLE
REST cache now stored in download cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Modified
 
 - added clarification for generating cache with an Alyx database in documentation
+- REST cache now stored in download cache directory
 
 ## [1.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - added clarification for generating cache with an Alyx database in documentation
 - REST cache now stored in download cache directory
+- JSON tests may now be run concurrently
 
 ## [1.11.0]
 

--- a/one/params.py
+++ b/one/params.py
@@ -282,27 +282,6 @@ def get_params_dir() -> Path:
     return Path(iopar.getfile(_PAR_ID_STR))
 
 
-def get_rest_dir(client=None) -> Path:
-    """Return path to REST cache directory
-
-    Parameters
-    ----------
-    client : str
-        Location of rest cache for a given database URL.  If None, the root REST cache directory is
-        returned
-
-    Returns
-    -------
-    pathlib.Path
-        The REST cache directory path
-    """
-    rest_dir = get_params_dir() / '.rest'
-    if client:
-        scheme, loc, *_ = urlsplit(client)
-        rest_dir /= Path(loc.replace(':', '_'), scheme)
-    return rest_dir
-
-
 def check_cache_conflict(cache_dir):
     """Asserts that a given directory is not currently used as a cache directory.
     This function checks whether a given directory is used as a cache directory for an Alyx

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -19,7 +19,6 @@ import iblutil.io.params as iopar
 
 from . import OFFLINE_ONLY, TEST_DB_1, TEST_DB_2
 from . import util
-from one.registration import RegistrationClient
 
 par = one.params.get(silent=True)
 
@@ -176,10 +175,11 @@ class TestJsonFieldMethods(unittest.TestCase):
         self.assertTrue(len(self.ac.get(url, expires=True)) == 1)
 
     def _json_field_remove_key(self):
+        eid = self.eids[1]
         url = f'/{self.endpoint}?&extended_qc=data__gte,0.5'
         pre_delete = self.ac.get(url, expires=True)
         self.assertTrue(len(pre_delete) == 2)
-        deleted = self.ac.json_field_remove_key(self.endpoint, self.eids[1], self.field_name, 'data')
+        deleted = self.ac.json_field_remove_key(self.endpoint, eid, self.field_name, 'data')
         self.assertTrue('data' not in deleted)
         post_delete = self.ac.get(url, expires=True)
         self.assertTrue(len(post_delete) == 1)
@@ -199,28 +199,29 @@ class TestJsonFieldMethods(unittest.TestCase):
 
     def test_empty(self):
         """Test for AlyxClient.json_field* methods when JSON field is empty"""
+        eid = self.eids[0]
         # Check behaviour when fields are empty
-        self.ac.rest(self.endpoint, 'partial_update', id=self.eids[0], data={self.field_name: None})
+        self.ac.rest(self.endpoint, 'partial_update', id=eid, data={self.field_name: None})
         # Should return None as no keys exist
-        modified = self.ac.json_field_remove_key(self.endpoint, self.eids[0], self.field_name, 'foo')
+        modified = self.ac.json_field_remove_key(self.endpoint, eid, self.field_name, 'foo')
         self.assertIsNone(modified)
         # Should return data
         data = {'some': 0.6}
-        modified = self.ac.json_field_update(self.endpoint, self.eids[0], self.field_name, data)
+        modified = self.ac.json_field_update(self.endpoint, eid, self.field_name, data)
         self.assertTrue(modified == data)
         # Should warn if key not in dict
         with self.assertLogs(logging.getLogger('one.webclient'), logging.WARNING):
-            self.ac.json_field_remove_key(self.endpoint, self.eids[0], self.field_name, 'foo')
+            self.ac.json_field_remove_key(self.endpoint, eid, self.field_name, 'foo')
         # Check behaviour when fields not a dict
         data = {self.field_name: json.dumps(data)}
-        self.ac.rest(self.endpoint, 'partial_update', id=self.eids[0], data=data)
+        self.ac.rest(self.endpoint, 'partial_update', id=eid, data=data)
         # Update field
         with self.assertLogs(logging.getLogger('one.webclient'), logging.WARNING):
-            modified = self.ac.json_field_update(self.endpoint, self.eids[0], self.field_name, data)
+            modified = self.ac.json_field_update(self.endpoint, eid, self.field_name, data)
         self.assertEqual(data[self.field_name], modified)
         # Remove key
         with self.assertLogs(logging.getLogger('one.webclient'), logging.WARNING):
-            modified = self.ac.json_field_remove_key(self.endpoint, self.eids[0], self.field_name)
+            modified = self.ac.json_field_remove_key(self.endpoint, eid, self.field_name)
         self.assertIsNone(modified)
 
     def tearDown(self):

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -1,7 +1,6 @@
 """Unit tests for the one.webclient module"""
 import unittest
 from unittest import mock
-from pathlib import Path
 import random
 import os
 import io
@@ -230,14 +229,13 @@ class TestRestCache(unittest.TestCase):
     """Tests for REST caching system, the cache decorator and cache flags"""
     def setUp(self):
         util.setup_test_params()  # Ensure test alyx set up
-        util.setup_rest_cache()  # Copy rest cache fixtures
+        util.setup_rest_cache(ac.cache_dir)  # Copy rest cache fixtures
         self.query = '/insertions/b529f2d8-cdae-4d59-aba2-cbd1b5572e36'
         self.tempdir = util.set_up_env()
         self.addCleanup(self.tempdir.cleanup)
         one.webclient.datetime = _FakeDateTime
         _FakeDateTime._now = None
-        path_parts = ('.rest', one.params._key_from_url(TEST_DB_1['base_url']), 'https')
-        self.cache_dir = Path(one.params.get_params_dir()).joinpath(*path_parts)
+        self.cache_dir = ac.cache_dir.joinpath('.rest')
         self.default_expiry = ac.default_expiry
         self.cache_mode = ac.cache_mode
 

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1502,12 +1502,18 @@ class TestOneSetup(unittest.TestCase):
         old_pars = (one.params.default()
                     .set('CACHE_DIR', self.tempdir.name)
                     .set('HTTP_DATA_SERVER', 'openalyx.org'))
+        # Save a REST query in the old location
+        old_rest = Path(self.tempdir.name, '.one', '.rest', old_pars.ALYX_URL[8:], 'https')
+        old_rest.mkdir(parents=True, exist_ok=True)
+        old_rest.joinpath('1baff95c2d0e31059720a3716ad5b5a34b61a207').touch()
 
         with mock.patch('iblutil.io.params.getfile', new=self.get_file):
             one.params.setup(silent=True)
             one.params.save(old_pars, old_pars.ALYX_URL)
             one_obj = ONE(base_url=old_pars.ALYX_URL, mode='local')
         self.assertEqual(one_obj.alyx._par.HTTP_DATA_SERVER, one.params.default().HTTP_DATA_SERVER)
+        self.assertFalse(Path(self.tempdir.name, '.rest').exists())
+        self.assertTrue(any(one_obj.alyx.cache_dir.joinpath('.rest').glob('*')))
 
     def test_one_factory(self):
         """Tests the ONE class factory"""

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -833,7 +833,7 @@ class TestOneAlyx(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.tempdir = util.set_up_env(use_temp_cache=False)
+        cls.tempdir = util.set_up_env()
         with mock.patch('one.params.iopar.getfile', new=partial(util.get_file, cls.tempdir.name)):
             # util.setup_test_params(token=True)
             cls.one = OneAlyx(
@@ -1498,7 +1498,6 @@ class TestOneSetup(unittest.TestCase):
 
     def test_patch_params(self):
         """Test patching legacy params to the new location"""
-
         # Save some old-style params
         old_pars = (one.params.default()
                     .set('CACHE_DIR', self.tempdir.name)

--- a/one/tests/test_params.py
+++ b/one/tests/test_params.py
@@ -87,20 +87,6 @@ class TestONEParamUtil(unittest.TestCase):
         self.assertIsInstance(path, Path)
         self.assertEqual('path/to/params/.one', path.as_posix())
 
-    def test_get_rest_dir(self):
-        """Test for one.params.get_rest_dir"""
-        par_dir = Path('path', 'to', 'params')
-        url = 'https://sub.domain.net/'
-        with mock.patch('iblutil.io.params.getfile', new=partial(util.get_file, par_dir)):
-            path1 = params.get_rest_dir()
-            path2 = params.get_rest_dir(url)
-
-        expected = ('path', 'to', 'params', '.one', '.rest')
-        self.assertCountEqual(expected, path1.parts)
-
-        expected = (*expected, 'sub.domain.net', 'https')
-        self.assertCountEqual(expected, path2.parts)
-
     def test_get_default_client(self):
         """Test for one.params.get_default_client"""
         temp_dir = util.set_up_env()

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -28,7 +28,7 @@ class TestRegistrationClient(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.temp_dir = util.set_up_env(use_temp_cache=False)
+        cls.temp_dir = util.set_up_env()
         cls.one = ONE(**TEST_DB_1, cache_dir=cls.temp_dir.name)
         cls.subject = ''.join(random.choices(string.ascii_letters, k=10))
         cls.one.alyx.rest('subjects', 'create', data={'lab': 'mainenlab', 'nickname': cls.subject})

--- a/one/tests/test_remote.py
+++ b/one/tests/test_remote.py
@@ -91,8 +91,8 @@ class TestBase(unittest.TestCase):
 
     def test_repo_from_alyx(self):
         """Test for DownloadClient.repo_from_alyx method"""
-        setup_rest_cache()  # Copy REST cache fixtures to temp dir
         ac = AlyxClient(**TEST_DB_1)
+        setup_rest_cache(ac.cache_dir)  # Copy REST cache fixtures to temp dir
         record = base.DownloadClient.repo_from_alyx('mainenlab', ac)
         self.assertEqual('mainenlab', record['name'])
 
@@ -222,8 +222,8 @@ class TestGlobus(unittest.TestCase):
     def test_get_lab_from_endpoint_id(self):
         """Tests for one.remote.globus.get_lab_from_endpoint_id function"""
         # Set up REST cache fixtures
-        setup_rest_cache()
         ac = AlyxClient(**TEST_DB_1)
+        setup_rest_cache(ac.cache_dir)
         endpoint_id = '2dc8ccc6-2f8e-11e9-9351-0e3d676669f4'
         name = globus.get_lab_from_endpoint_id(endpoint_id, ac)[0]
         self.assertEqual(name, 'mainenlab')
@@ -320,8 +320,8 @@ class TestGlobusClient(unittest.TestCase):
 
         # Test with Alyx repo name
         # Set up REST cache fixtures
-        setup_rest_cache()
         ac = AlyxClient(**TEST_DB_1)
+        setup_rest_cache(ac.cache_dir)
         name = 'mainenlab'
         self.client.add_endpoint(name, alyx=ac)
         self.assertIn(name, self.client.endpoints)


### PR DESCRIPTION
Moved the REST cache directory from the one params folder to the download cache folder of the Alyx client.
**Motivation**
All data are encapsulated within the cache directory: if users want to 'freeze' their analysis, including the REST query output, this will keep the other instance of ONE from overwriting the cache.
**Side effects**
After upgrading, changing the cache directory will mean a whole new rest cache, even for the same database