### PR TITLE
v1.13.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coverage coveralls
         pip install -r requirements.txt
-        pip install boto3 globus_sdk
+        pip install globus_sdk
         pip install -e .
     - name: run tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Modified
 
+- cache 'project' field renamed to 'projects'
 - iter_datasets now public function in one.alf.io, moved from one.alf.cache
 - expose register_session kwargs in RegistrationClient.create_session method
 - one.remote.aws.get_aws_access_keys requires AlyxClient instance instead of OneAlyx, in line with one.remote.globus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.12.2]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.13.0]
+
+### Added
+
+- one.remote.aws.get_s3_virtual_host constructs HTTPS Web address from bucket name and region
+- one.remote.aws.is_folder determines if an S3 Object is a folder
+
+### Modified
+
+- iter_datasets now public function in one.alf.io, moved from one.alf.cache
+- expose register_session kwargs in RegistrationClient.create_session method
+- one.remote.aws.get_aws_access_keys requires AlyxClient instance instead of OneAlyx, in line with one.remote.globus
+
+## [1.12.2]
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - one.remote.aws.get_s3_virtual_host constructs HTTPS Web address from bucket name and region
 - one.remote.aws.is_folder determines if an S3 Object is a folder
+- boto3 now a requirement
 
 ### Modified
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The Open Neurophysiology Environment is a scheme for sharing neurophysiology data in a standardized manner. For information on how to share data with ONE please [click here](https://github.com/int-brain-lab/ONE/blob/main/docs/Open_Neurophysiology_Environment_Filename_Convention.pdf). This github page contains an API for searching and loading ONE-standardized data, stored either on a user’s local machine or on a remote server. Please [Click here](https://int-brain-lab.github.io/ONE/) for the main documentation page.
 
+**NB**: The API and backend database are still under active development, for the best experience please regularly update the package by running `pip install -U ONE-api`. 
+
 ## Requirements
 ONE runs on Python 3.7 or later, and is tested on the latest Ubuntu and Windows (3.7 and 3.8 only).
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.12.2'
+__version__ = '1.13.0'

--- a/one/alf/cache.py
+++ b/one/alf/cache.py
@@ -42,7 +42,7 @@ SESSIONS_COLUMNS = (
     'date',             # datetime.date
     'number',           # int
     'task_protocol',
-    'project',
+    'projects',
 )
 
 DATASETS_COLUMNS = (
@@ -72,7 +72,7 @@ def _get_session_info(rel_ses_path):
     out['date'] = pd.to_datetime(out['date']).date()
     out['number'] = int(out['number'])
     out['task_protocol'] = ''
-    out['project'] = ''
+    out['projects'] = ''
     return out
 
 

--- a/one/alf/io.py
+++ b/one/alf/io.py
@@ -364,23 +364,42 @@ def _ls(alfpath, object=None, **kwargs) -> (list, tuple):
 
 def iter_sessions(root_dir):
     """
-    Recursively iterate over session paths in a given directory
+    Recursively iterate over session paths in a given directory.
 
     Parameters
     ----------
     root_dir : str, pathlib.Path
-        The folder to look for sessions
+        The folder to look for sessions.
 
     Yields
     -------
     pathlib.Path
-        The next session path in lexicographical order
+        The next session path in lexicographical order.
     """
     if spec.is_session_path(root_dir):
         yield root_dir
     for path in sorted(Path(root_dir).rglob('*')):
         if path.is_dir() and spec.is_session_path(path):
             yield path
+
+
+def iter_datasets(session_path):
+    """
+    Iterate over all files in a session, and yield relative dataset paths.
+
+    Parameters
+    ----------
+    session_path : str, pathlib.Path
+        The folder to look for datasets.
+
+    Yields
+    -------
+    pathlib.Path
+        The next dataset path (relative to the session path) in lexicographical order.
+    """
+    for p in sorted(Path(session_path).rglob('*.*')):
+        if not p.is_dir() and spec.is_valid(p.name):
+            yield p.relative_to(session_path)
 
 
 def exists(alfpath, object, attributes=None, **kwargs) -> bool:

--- a/one/api.py
+++ b/one/api.py
@@ -221,7 +221,7 @@ class One(ConversionMixin):
         strict : bool
             If not True, the columns don't need to match.  Extra columns in input tables are
             dropped and missing columns are added and filled with np.nan.
-        kwargs
+        **kwargs
             pandas.DataFrame or pandas.Series to insert/update for each table
 
         Returns
@@ -869,7 +869,7 @@ class One(ConversionMixin):
         download_only : bool
             When true the data are downloaded and the file path is returned. NB: The order of the
             file path list is undefined.
-        kwargs : dict
+        **kwargs
             Additional filters for datasets, including namespace and timescale. For full list
             see the one.alf.spec.describe function.
 
@@ -1201,7 +1201,7 @@ class One(ConversionMixin):
             Query cache ('local') or Alyx database ('remote')
         download_only : bool
             When true the data are downloaded and the file path is returned.
-        kwargs : dict
+        **kwargs
             Additional filters for datasets, including namespace and timescale. For full list
             see the one.alf.spec.describe function.
 
@@ -1268,6 +1268,9 @@ class One(ConversionMixin):
         silent : (False) bool
             when True will prompt for cache_dir if cache_dir is None, and overwrite cache if any
             when False will use cwd for cache_dir if cache_dir is None and use existing cache
+        **kwargs
+            Optional arguments to pass to one.alf.cache.make_parquet_db.
+
         Returns
         -------
         One
@@ -1665,10 +1668,10 @@ class OneAlyx(One):
             _logger.debug(ex)
         return self._download_dataset(dsets, **kwargs)
 
-    def _download_aws(self, dsets, update_exists=True, **kwargs) -> List[Path]:
+    def _download_aws(self, dsets, update_exists=True, **_) -> List[Path]:
         # Download datasets from AWS
         import one.remote.aws as aws
-        s3, bucket_name = aws.get_s3_from_alyx(self)
+        s3, bucket_name = aws.get_s3_from_alyx(self.alyx)
         if self._index_type() is int:
             raise NotImplementedError('AWS download only supported for str index cache')
         assert self.mode != 'local'
@@ -1908,6 +1911,8 @@ class OneAlyx(One):
         ----------
         base_url : str
             An Alyx database URL.  If None, the current default database is used.
+        **kwargs
+            Optional arguments to pass to one.params.setup.
 
         Returns
         -------

--- a/one/api.py
+++ b/one/api.py
@@ -38,7 +38,7 @@ N_THREADS = 4
 class One(ConversionMixin):
     """An API for searching and loading data on a local filesystem"""
     _search_terms = (
-        'dataset', 'date_range', 'laboratory', 'number', 'project', 'subject', 'task_protocol'
+        'dataset', 'date_range', 'laboratory', 'number', 'projects', 'subject', 'task_protocol'
     )
 
     def __init__(self, cache_dir=None, mode='auto', wildcards=True):
@@ -99,8 +99,8 @@ class One(ConversionMixin):
                 continue
             meta['loaded_time'] = datetime.now()
 
-            # Convert to str ids
-            cache = util.cache_int2str(cache)
+            # Patch older tables
+            cache = util.patch_cache(cache, meta['raw'][table].get('min_api_version'))
 
             # Set the appropriate index if none already set
             if isinstance(cache.index, pd.RangeIndex):
@@ -385,8 +385,8 @@ class One(ConversionMixin):
         task_protocol : str
             The task protocol name (can be partial, i.e. any task protocol containing that str
             will be found)
-        project : str
-            The project name (can be partial, i.e. any task protocol containing that str
+        projects : str, list
+            The project name(s) (can be partial, i.e. any project containing that str
             will be found)
         details : bool
             If true also returns a dict of dataset details
@@ -424,7 +424,7 @@ class One(ConversionMixin):
             if sessions.size == 0:
                 return ([], None) if details else []
             # String fields
-            elif key in ('subject', 'task_protocol', 'laboratory', 'project'):
+            elif key in ('subject', 'task_protocol', 'laboratory', 'projects'):
                 query = '|'.join(util.ensure_list(value))
                 key = 'lab' if key == 'laboratory' else key
                 mask = sessions[key].str.contains(query, regex=self.wildcards)
@@ -1586,7 +1586,7 @@ class OneAlyx(One):
         task_protocol : str, list
             The task protocol name (can be partial, i.e. any task protocol containing that str
             will be found)
-        project : str, list
+        project(s) : str, list
             The project name (can be partial, i.e. any task protocol containing that str
             will be found)
         performance_lte / performance_gte : float
@@ -2176,9 +2176,10 @@ class OneAlyx(One):
         if full:
             return dets
         # If it's not full return the normal output like from a one.search
-        det_fields = ['subject', 'start_time', 'number', 'lab', 'project',
+        det_fields = ['subject', 'start_time', 'number', 'lab', 'projects',
                       'url', 'task_protocol', 'local_path']
         out = {k: v for k, v in dets.items() if k in det_fields}
+        out['projects'] = ','.join(out['projects'])
         out.update({'local_path': self.eid2path(eid),
                     'date': datetime.fromisoformat(out['start_time']).date()})
         return out

--- a/one/registration.py
+++ b/one/registration.py
@@ -81,22 +81,24 @@ class RegistrationClient:
             flag_file.unlink()
         return [ff.parent for ff in flag_files], records
 
-    def create_session(self, session_path) -> dict:
+    def create_session(self, session_path, **kwargs) -> dict:
         """Create a remote session on Alyx from a local session path, without registering files
 
         Parameters
         ----------
         session_path : str, pathlib.Path
-            The path ending with subject/date/number
+            The path ending with subject/date/number.
+        **kwargs
+            Optional arguments for RegistrationClient.register_session.
 
         Returns
         -------
         dict
-            Newly created session record
+            Newly created session record.
         """
-        return self.register_session(session_path, file_list=False)[0]
+        return self.register_session(session_path, file_list=False, **kwargs)[0]
 
-    def create_new_session(self, subject, session_root=None, date=None, register=True):
+    def create_new_session(self, subject, session_root=None, date=None, register=True, **kwargs):
         """Create a new local session folder and optionally create session record on Alyx
 
         Parameters
@@ -110,12 +112,14 @@ class RegistrationClient:
             An optional date for the session.  If None the current time is used.
         register : bool
             If true, create session record on Alyx database
+        **kwargs
+            Optional arguments for RegistrationClient.register_session.
 
         Returns
         -------
         pathlib.Path
             New local session path
-        str
+        uuid.UUID
             The experiment UUID if register is True
 
         Examples
@@ -139,7 +143,7 @@ class RegistrationClient:
         session_root = Path(session_root or self.one.alyx.cache_dir) / subject / date[:10]
         session_path = session_root / alfio.next_num_folder(session_root)
         session_path.mkdir(exist_ok=True, parents=True)  # Ensure folder exists on disk
-        eid = UUID(self.create_session(session_path)['url'][-36:]) if register else None
+        eid = UUID(self.create_session(session_path, **kwargs)['url'][-36:]) if register else None
         return session_path, eid
 
     def find_files(self, session_path):

--- a/one/registration.py
+++ b/one/registration.py
@@ -252,7 +252,7 @@ class RegistrationClient:
             The total number of completed trials (optional)
         json : dict, str
             Optional JSON data
-        project: str, list
+        projects: str, list
             The project(s) to which the experiment belongs (optional)
         type : str
             The experiment type, e.g. 'Experiment', 'Base'
@@ -315,6 +315,8 @@ class RegistrationClient:
         assert start_time[:10] == details['date'], 'start_time doesn\'t match session path'
         if kwargs.get('procedures', False):
             ses_['procedures'] = ensure_list(kwargs.pop('procedures'))
+        if kwargs.get('projects', False):
+            ses_['projects'] = ensure_list(kwargs.pop('projects'))
         assert ('subject', 'number') not in kwargs
         if 'lab' not in kwargs and details['lab']:
             kwargs.update({'lab': details['lab']})

--- a/one/remote/aws.py
+++ b/one/remote/aws.py
@@ -1,22 +1,24 @@
 """A backend to download IBL data from AWS Buckets.
 
 For example, without any credentials, to download a public file from the IBL public bucket:
-```
-import one.remote.aws as aws
-source = 'caches/unit_test/cache_info.json'
-destination = '/home/olivier/scratch/cache_info.json'
-aws.s3_download_file(source, destination)
 
-For a folder, the following
-```
-source = 'caches/unit_test'
-destination = '/home/olivier/scratch/caches/unit_test'
-local_files = aws.s3_download_folder(source, destination)
+>>> import one.remote.aws as aws
+>>> source = 'caches/unit_test/cache_info.json'
+>>> destination = '/home/olivier/scratch/cache_info.json'
+>>> aws.s3_download_file(source, destination)
+
+For a folder, the following:
+
+>>> source = 'caches/unit_test'
+>>> destination = '/home/olivier/scratch/caches/unit_test'
+>>> local_files = aws.s3_download_folder(source, destination)
 """
+import re
 from pathlib import Path
 import logging
-from tqdm import tqdm
+import urllib.parse
 
+from tqdm import tqdm
 import boto3
 
 from botocore import UNSIGNED
@@ -50,14 +52,59 @@ def _callback_hook(t):
     return inner
 
 
-def get_aws_access_keys(one, repo_name=REPO_DEFAULT):
+def get_s3_virtual_host(uri, region) -> str:
+    """
+    Convert a given bucket URI to a generic Amazon virtual host URL.
+    URI may be the bucket (+ path) or a full URI starting with 's3://'
+
+    .. _S3 documentation
+       https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html#virtual-host-style-url-ex
+
+    Parameters
+    ----------
+    uri : str
+        The bucket name or full path URI.
+    region : str
+        The region, e.g. eu-west-1.
+
+    Returns
+    -------
+    str
+        The Web URL (virtual host name and https scheme).
+    """
+    assert region and re.match(r'\w{2}-\w+-[1-3]', region), 'Invalid region'
+    parsed = urllib.parse.urlparse(uri)  # remove scheme if necessary
+    key = parsed.path.strip('/').split('/')
+    bucket = parsed.netloc or key.pop(0)
+    hostname = f"{bucket}.{parsed.scheme or 's3'}.{region}.amazonaws.com"
+    return 'https://' + '/'.join((hostname, *key))
+
+
+def is_folder(obj_summery) -> bool:
+    """
+    Given an S3 ObjectSummery instance, returns true if the associated object is a directory.
+
+    Parameters
+    ----------
+    obj_summery : s3.ObjectSummery
+        An S3 ObjectSummery instance to test.
+
+    Returns
+    -------
+    bool
+        True if object is a directory.
+    """
+    return obj_summery.key.endswith('/') and obj_summery.size == 0
+
+
+def get_aws_access_keys(alyx, repo_name=REPO_DEFAULT):
     """
     Query Alyx database to get credentials in the json field of an aws repository.
 
     Parameters
     ----------
-    one : one.OneAlyx
-        An online instance of ONE.
+    alyx : one.webclient.AlyxInstance
+        An instance of alyx.
     repo_name : str
         The data repository name in Alyx from which to fetch the S3 access keys.
 
@@ -68,7 +115,7 @@ def get_aws_access_keys(one, repo_name=REPO_DEFAULT):
     str
         The name of the S3 bucket associated with the Alyx data repository.
     """
-    repo_json = one.alyx.rest('data-repository', 'read', id=repo_name)['json']
+    repo_json = alyx.rest('data-repository', 'read', id=repo_name)['json']
     bucket_name = repo_json['bucket_name']
     session_keys = {
         'aws_access_key_id': repo_json.get('Access key ID', None),
@@ -94,14 +141,14 @@ def get_s3_public():
     return s3, S3_BUCKET_IBL
 
 
-def get_s3_from_alyx(one, repo_name=REPO_DEFAULT):
+def get_s3_from_alyx(alyx, repo_name=REPO_DEFAULT):
     """
     Create an S3 resource instance using credentials from an Alyx data repository.
 
     Parameters
     ----------
-    one : one.OneAlyx
-        An online instance of ONE.
+    alyx : one.webclient.AlyxInstance
+        An instance of alyx.
     repo_name : str
         The data repository name in Alyx from which to fetch the S3 access keys.
 
@@ -112,7 +159,7 @@ def get_s3_from_alyx(one, repo_name=REPO_DEFAULT):
     str
         The name of the S3 bucket.
     """
-    session_keys, bucket_name = get_aws_access_keys(one, repo_name)
+    session_keys, bucket_name = get_aws_access_keys(alyx, repo_name)
     session = boto3.Session(**session_keys)
     s3 = session.resource('s3')
     return s3, bucket_name
@@ -193,9 +240,8 @@ def s3_download_folder(source, destination, s3=None, bucket_name=S3_BUCKET_IBL, 
     if s3 is None:
         s3, bucket_name = get_s3_public()
     local_files = []
-    for obj_summary in s3.Bucket(name=bucket_name).objects.filter(Prefix=source):
-        if obj_summary.key.endswith('/') and obj_summary.size == 0:  # skips folder
-            continue
+    objects = s3.Bucket(name=bucket_name).objects.filter(Prefix=source)
+    for obj_summary in filter(lambda x: not is_folder(x), objects):
         local_file = Path(destination).joinpath(Path(obj_summary.key).relative_to(source))
         lf = s3_download_file(obj_summary.key, local_file, s3=s3, bucket_name=bucket_name,
                               overwrite=overwrite)

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -577,8 +577,8 @@ class TestALFFolders(unittest.TestCase):
         cls.tempdir.cleanup()
 
     def tearDown(self) -> None:
-        for file in self.session_path.rglob('*.*'):
-            file.unlink()
+        for obj in reversed(sorted(Path(self.session_path).rglob('*'))):
+            obj.unlink() if obj.is_file() else obj.rmdir()
 
     def test_next_num_folder(self):
         """Test for one.alf.io.next_num_folder"""

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -563,6 +563,7 @@ class TestUUID_Files(unittest.TestCase):
 
 class TestALFFolders(unittest.TestCase):
     tempdir = None
+    session_path = None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -575,7 +576,12 @@ class TestALFFolders(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.tempdir.cleanup()
 
+    def tearDown(self) -> None:
+        for file in self.session_path.rglob('*.*'):
+            file.unlink()
+
     def test_next_num_folder(self):
+        """Test for one.alf.io.next_num_folder"""
         self.session_path.rmdir()  # Remove '001' folder
         next_num = alfio.next_num_folder(self.session_path.parent)
         self.assertEqual('001', next_num)
@@ -601,6 +607,7 @@ class TestALFFolders(unittest.TestCase):
             alfio.next_num_folder(self.session_path.parent)
 
     def test_remove_empty_folders(self):
+        """Test for one.alf.io.remove_empty_folders"""
         root = Path(self.tempdir.name) / 'glob_dir'
         root.mkdir()
         root.joinpath('empty0').mkdir(exist_ok=True)
@@ -611,6 +618,7 @@ class TestALFFolders(unittest.TestCase):
         self.assertTrue(len(list(root.glob('*'))) == 1)
 
     def test_iter_sessions(self):
+        """Test for one.alf.io.iter_sessions"""
         # Create invalid session folder
         self.session_path.parent.parent.joinpath('bad_session').mkdir()
 
@@ -619,6 +627,18 @@ class TestALFFolders(unittest.TestCase):
         self.assertFalse(next(valid_sessions, False))
         # makes sure that the session path returns itself on the iterator
         self.assertEqual(self.session_path, next(alfio.iter_sessions(self.session_path)))
+
+    def test_iter_datasets(self):
+        """Test for one.alf.io.iter_datasets"""
+        # Create valid dataset
+        dset = self.session_path.joinpath('collection', 'object.attribute.ext')
+        dset.parent.mkdir()
+        dset.touch()
+        # Create invalid dataset
+        self.session_path.joinpath('somefile.txt').touch()
+
+        ses_files = list(alfio.iter_datasets(self.session_path))
+        self.assertEqual([Path(*dset.parts[-2:])], ses_files)
 
 
 if __name__ == "__main__":

--- a/one/tests/alf/test_cache.py
+++ b/one/tests/alf/test_cache.py
@@ -21,7 +21,7 @@ class TestsONEParquet(unittest.TestCase):
         'subject': 'mysub',
         'date': datetime.date.fromisoformat('2021-02-28'),
         'number': int('001'),
-        'project': '',
+        'projects': '',
         'task_protocol': '',
         'id': 'mylab/mysub/2021-02-28/001',
     }

--- a/one/tests/alf/test_cache.py
+++ b/one/tests/alf/test_cache.py
@@ -54,10 +54,6 @@ class TestsONEParquet(unittest.TestCase):
         self.assertTrue(
             self.full_ses_path.as_posix().endswith(self.rel_ses_path[:-1]))
 
-    def test_walk_session(self):
-        ses_files = list(apt._iter_datasets(self.full_ses_path))
-        self.assertEqual(ses_files, self.rel_ses_files)
-
     def test_parquet(self):
         # Test data
         columns = ('colA', 'colB')

--- a/one/tests/remote/test_remote.py
+++ b/one/tests/remote/test_remote.py
@@ -16,7 +16,7 @@ import random
 try:
     import globus_sdk
 except ModuleNotFoundError:
-    unittest.skip('globus_sdk module not installed')
+    raise unittest.skip('globus_sdk module not installed')
 from iblutil.io import params as iopar
 
 from one.tests.util import get_file, setup_rest_cache

--- a/one/tests/remote/test_remote_aws.py
+++ b/one/tests/remote/test_remote_aws.py
@@ -12,7 +12,7 @@ from one.webclient import AlyxClient
 try:
     import one.remote.aws as aws
 except ModuleNotFoundError:
-    unittest.skip('boto3 module not installed')
+    raise unittest.SkipTest('boto3 module not installed')
 
 
 @unittest.skipIf(OFFLINE_ONLY, 'online only test')

--- a/one/tests/remote/test_remote_aws.py
+++ b/one/tests/remote/test_remote_aws.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from functools import partial
 
 from one.tests import TEST_DB_1, OFFLINE_ONLY, util
-from one.api import OneAlyx
+from one.webclient import AlyxClient
 try:
     import one.remote.aws as aws
 except ModuleNotFoundError:
@@ -69,15 +69,14 @@ class TestAWS(unittest.TestCase):
         cls.tempdir = util.set_up_env()
         with mock.patch('one.params.iopar.getfile', new=partial(util.get_file, cls.tempdir.name)):
             # util.setup_test_params(token=True)
-            cls.one = OneAlyx(
+            cls.alyx = AlyxClient(
                 **TEST_DB_1,
-                cache_dir=cls.tempdir.name,
-                mode='local'
+                cache_dir=cls.tempdir.name
             )
 
     def test_credentials(self):
         """Test for one.remote.aws.get_aws_access_keys function."""
-        cred, bucket_name = aws.get_aws_access_keys(self.one, 'aws_cortexlab')
+        cred, bucket_name = aws.get_aws_access_keys(self.alyx, 'aws_cortexlab')
         expected = {
             'aws_access_key_id': 'ABCDEF',
             'aws_secret_access_key': 'shhh',
@@ -85,3 +84,23 @@ class TestAWS(unittest.TestCase):
         }
         self.assertDictEqual(cred, expected)
         self.assertEqual(bucket_name, 's3_bucket')
+
+
+class TestUtils(unittest.TestCase):
+    """Tests for one.remote.aws utility functions"""
+
+    def test_get_s3_virtual_host(self):
+        """Tests for one.remote.aws.get_s3_virtual_host function"""
+        expected = 'https://my-s3-bucket.s3.eu-east-1.amazonaws.com/'
+        url = aws.get_s3_virtual_host('s3://my-s3-bucket', 'eu-east-1')
+        self.assertEqual(expected, url)
+
+        # NB slight diff in behaviour: with no scheme provided output URL has no trailing slash.
+        url = aws.get_s3_virtual_host('my-s3-bucket/', 'eu-east-1')
+        self.assertEqual(expected.strip('/'), url)
+        expected = 'https://my-s3-bucket.s3.eu-east-1.amazonaws.com/path/to/file'
+        url = aws.get_s3_virtual_host('s3://my-s3-bucket/path/to/file', 'eu-east-1')
+        self.assertEqual(expected, url)
+
+        with self.assertRaises(AssertionError):
+            aws.get_s3_virtual_host('s3://my-s3-bucket/path/to/file', 'wrong-foo-4')

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1176,7 +1176,7 @@ class TestOneRemote(unittest.TestCase):
         self.assertTrue(correct)
 
         # Check minimum set of keys present (these are present in One.search output)
-        expected = {'lab', 'subject', 'date', 'number', 'project'}
+        expected = {'lab', 'subject', 'date', 'number', 'projects'}
         self.assertTrue(det[0].keys() >= expected)
         # Test dataset search with Django
         eids = self.one.search(subject='SWC_043', dataset=['probes.description'], number=1,
@@ -1235,6 +1235,7 @@ class TestOneRemote(unittest.TestCase):
         det = self.one.get_details(self.eid, query_type='remote')
         self.assertIsInstance(det, dict)
         self.assertEqual('SWC_043', det['subject'])
+        self.assertEqual('ibl_neuropixel_brainwide_01', det['projects'])
         self.assertEqual('2020-09-21', str(det['date']))
         self.assertEqual(1, det['number'])
         self.assertNotIn('data_dataset_session_related', det)

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -7,6 +7,7 @@ import random
 import datetime
 import fnmatch
 from io import StringIO
+from pathlib import Path
 
 from iblutil.util import Bunch
 from requests.exceptions import HTTPError
@@ -116,7 +117,7 @@ class TestRegistrationClient(unittest.TestCase):
         removed = self.client.dtypes.pop(next(i for i, x in enumerate(existing) if x))
         files = list(self.client.find_files(self.session_path))
         self.assertEqual(6, len(files))
-        self.assertTrue(all(x.is_file() for x in files))
+        self.assertTrue(all(map(Path.is_file, files)))
         # Check removed file pattern not in file list
         self.assertFalse(fnmatch.filter([x.name for x in files], removed['filename_pattern']))
 

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -124,10 +124,15 @@ class TestRegistrationClient(unittest.TestCase):
     def test_create_new_session(self):
         """Test for RegistrationClient.create_new_session"""
         # Check register = True
-        session_path, eid = self.client.create_new_session(self.subject, date='2020-01-01')
+        session_path, eid = self.client.create_new_session(
+            self.subject, date='2020-01-01', projects='ibl_neuropixel_brainwide_01'
+        )
         expected = self.one.alyx.cache_dir.joinpath(self.subject, '2020-01-01', '001').as_posix()
         self.assertEqual(session_path.as_posix(), expected)
         self.assertIsNotNone(eid)
+        # Check projects added to Alyx session
+        projects = self.one.get_details(eid, full=True)['projects']
+        self.assertEqual(projects, ['ibl_neuropixel_brainwide_01'])
         # Check register = False
         session_path, eid = self.client.create_new_session(
             self.subject, date='2020-01-01', register=False)

--- a/one/util.py
+++ b/one/util.py
@@ -45,11 +45,12 @@ def ses2records(ses: dict, int_id=False):
     eid = ses['url'][-36:]
     if int_id:
         eid = tuple(parquet.str2np(eid).flatten())
-    session_keys = ('subject', 'start_time', 'lab', 'number', 'task_protocol', 'project')
+    session_keys = ('subject', 'start_time', 'lab', 'number', 'task_protocol', 'projects')
     session_data = {k: v for k, v in ses.items() if k in session_keys}
     session = (
         pd.Series(data=session_data, name=eid).rename({'start_time': 'date'})
     )
+    session['project'] = ','.join(session.pop('projects'))
     session['date'] = datetime.fromisoformat(session['date']).date()
 
     # Extract datasets table

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm>=4.32.1
 requests>=2.22.0
 iblutil>=1.1.0
 packaging
+boto3


### PR DESCRIPTION
### Added

- one.remote.aws.get_s3_virtual_host constructs HTTPS Web address from bucket name and region
- one.remote.aws.is_folder determines if an S3 Object is a folder

### Modified

- iter_datasets now public function in one.alf.io, moved from one.alf.cache
- expose register_session kwargs in RegistrationClient.create_session method
- one.remote.aws.get_aws_access_keys requires AlyxClient instance instead of OneAlyx, in line with one.remote.globus
- ses2records now handles projects field