### PR TITLE
1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.13.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.14.0]
+
+### Added
+
+- function to remove cache files and folders that are not in datasets cache table
+
+### Modified
+
+- bugfix: load interpolate timestamps with timescale
+- bugfix: username now passed to parameter setup routine
+- in silent mode if token invalid the user is logged out to remove old token from param file
+- root_dir now optional input for session_record2path
+
+## [1.13.0]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - bugfix: username now passed to parameter setup routine
 - in silent mode if token invalid the user is logged out to remove old token from param file
 - root_dir now optional input for session_record2path
+- do not check for recent cache upon instantiation in remote mode 
 
 ## [1.13.0]
 

--- a/docs/notebooks/alyx_files.ipynb
+++ b/docs/notebooks/alyx_files.ipynb
@@ -9,8 +9,8 @@
     }
    },
    "source": [
-    "# Listing Alyx Files\n",
-    "An ALyx File (ALF) is any file whose path matches a specific pattern.  We will use the following\n",
+    "# Listing Alyx Filenames\n",
+    "An ALyx Filename (ALF) is any file whose path matches a specific pattern.  We will use the following\n",
     "file structure as an example:\n",
     "\n",
     "    subject/\n",

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.13.0'
+__version__ = '1.14.0'

--- a/one/alf/README.md
+++ b/one/alf/README.md
@@ -1,4 +1,4 @@
-# ALyx Files (ALF)
+# ALyx Filenames (ALF)
 This package is concerned with parsing and loading files that follow the Alyx file name specification.
 Files should be organized in folders by subject name, date and session number, for example:
 ```text

--- a/one/alf/io.py
+++ b/one/alf/io.py
@@ -255,10 +255,11 @@ def check_dimensions(dico):
     """
     supported = (np.ndarray, pd.DataFrame)  # Data types that have a shape attribute
     shapes = [dico[lab].shape for lab in dico
-              if isinstance(dico[lab], supported) and lab.split('.')[0] != 'timestamps']
+              if isinstance(dico[lab], supported) and not lab.startswith('timestamps')]
     first_shapes = [sh[0] for sh in shapes]
     # Continuous timeseries are permitted to be a (2, 2)
-    timeseries = [k for k, v in dico.items() if 'timestamps' in k and isinstance(v, np.ndarray)]
+    timeseries = [k for k, v in dico.items()
+                  if k.startswith('timestamps') and isinstance(v, np.ndarray)]
     if any(timeseries):
         for key in timeseries:
             if dico[key].ndim == 1 or (dico[key].ndim == 2 and dico[key].shape[1] == 1):

--- a/one/api.py
+++ b/one/api.py
@@ -1394,7 +1394,7 @@ class OneAlyx(One):
         cache_meta = self._cache['_meta']
         if not clobber:
             super(OneAlyx, self)._load_cache(self.cache_dir)  # Load any present cache
-            if (self._cache and not cache_meta['expired']) or self.mode == 'local':
+            if (self._cache and not cache_meta['expired']) or self.mode in ('local', 'remote'):
                 return
 
         # Warn user if expired

--- a/one/converters.py
+++ b/one/converters.py
@@ -180,10 +180,7 @@ class ConversionMixin:
         try:
             ses = self._cache['sessions'].loc[eid].squeeze()
             assert isinstance(ses, pd.Series), 'Duplicate eids in sessions table'
-            ses = ses.to_dict()
-            return Path(self.cache_dir).joinpath(
-                ses['lab'] if ses['lab'] else '', 'Subjects' if ses['lab'] else '', ses['subject'],
-                str(ses['date']), str(ses['number']).zfill(3))
+            return session_record2path(ses.to_dict(), self.cache_dir)
         except KeyError:
             return
 
@@ -735,3 +732,44 @@ def path_from_filerecord(fr, root_path=PurePosixPath('/'), uuid=None):
     if uuid:
         file_path = add_uuid_string(file_path, uuid)
     return file_path
+
+
+def session_record2path(session, root_dir=None):
+    """
+    Convert a session record into a path.
+
+    If a lab key is present, the path will be in the form
+    root_dir/lab/Subjects/subject/yyyy-mm-dd/nnn, otherwise root_dir/subject/yyyy-mm-dd/nnn.
+
+    Parameters
+    ----------
+    session : Mapping
+        A session record with keys ('subject', 'date', 'number'[, 'lab']).
+    root_dir : str, pathlib.Path, pathlib.PurePath
+        A root directory to prepend.
+
+    Returns
+    -------
+    pathlib.Path, Pathlib.PurePath
+        A constructed path of the session.
+
+    Examples
+    --------
+    >>> session_record2path({'subject': 'ALK01', 'date': '2020-01-01', 'number': 1})
+    PurePosixPath('ALK01/2020-01-01/001')
+
+    >>> record = {'date': datetime.datetime.fromisoformat('2020-01-01').date(),
+    ...           'number': '001', 'lab': 'foo', 'subject': 'ALK01'}
+    >>> session_record2path(record, Path('/home/user'))
+    Path('/home/user/foo/Subjects/ALK01/2020-01-01/001')
+    """
+    rel_path = PurePosixPath(
+        session['lab'] if session['lab'] else '',
+        'Subjects' if session['lab'] else '',
+        session['subject'], str(session['date']), str(session['number']).zfill(3)
+    )
+    if not root_dir:
+        return rel_path
+    elif isinstance(root_dir, str):
+        root_dir = Path(root_dir)
+    return Path(root_dir).joinpath(rel_path)

--- a/one/converters.py
+++ b/one/converters.py
@@ -764,8 +764,8 @@ def session_record2path(session, root_dir=None):
     Path('/home/user/foo/Subjects/ALK01/2020-01-01/001')
     """
     rel_path = PurePosixPath(
-        session['lab'] if session['lab'] else '',
-        'Subjects' if session['lab'] else '',
+        session.get('lab') if session.get('lab') else '',
+        'Subjects' if session.get('lab') else '',
         session['subject'], str(session['date']), str(session['number']).zfill(3)
     )
     if not root_dir:

--- a/one/remote/aws.py
+++ b/one/remote/aws.py
@@ -1,21 +1,19 @@
 """A backend to download IBL data from AWS Buckets.
 
-For example, without any credentials, to download a public file from the IBL public bucket:
+Examples
+--------
+Without any credentials, to download a public file from the IBL public bucket:
 
-```
-import one.remote.aws as aws
-source = 'caches/unit_test/cache_info.json'
-destination = '/home/olivier/scratch/cache_info.json'
-aws.s3_download_file(source, destination)
-```
+    from one.remote import aws
+    source = 'caches/unit_test/cache_info.json'
+    destination = '/home/olivier/scratch/cache_info.json'
+    aws.s3_download_file(source, destination)
 
-For a folder, the following
+For a folder, the following:
 
-```
-source = 'caches/unit_test'
-destination = '/home/olivier/scratch/caches/unit_test'
-local_files = aws.s3_download_folder(source, destination)
-```
+    source = 'caches/unit_test'
+    destination = '/home/olivier/scratch/caches/unit_test'
+    local_files = aws.s3_download_folder(source, destination)
 """
 from pathlib import Path
 import logging

--- a/one/remote/aws.py
+++ b/one/remote/aws.py
@@ -1,17 +1,21 @@
 """A backend to download IBL data from AWS Buckets.
 
 For example, without any credentials, to download a public file from the IBL public bucket:
+
 ```
 import one.remote.aws as aws
 source = 'caches/unit_test/cache_info.json'
 destination = '/home/olivier/scratch/cache_info.json'
 aws.s3_download_file(source, destination)
+```
 
 For a folder, the following
+
 ```
 source = 'caches/unit_test'
 destination = '/home/olivier/scratch/caches/unit_test'
 local_files = aws.s3_download_folder(source, destination)
+```
 """
 from pathlib import Path
 import logging

--- a/one/remote/aws.py
+++ b/one/remote/aws.py
@@ -4,16 +4,16 @@ Examples
 --------
 Without any credentials, to download a public file from the IBL public bucket:
 
-    from one.remote import aws
-    source = 'caches/unit_test/cache_info.json'
-    destination = '/home/olivier/scratch/cache_info.json'
-    aws.s3_download_file(source, destination)
+>>> from one.remote import aws
+... source = 'caches/unit_test/cache_info.json'
+... destination = '/home/olivier/scratch/cache_info.json'
+... aws.s3_download_file(source, destination)
 
 For a folder, the following:
 
-    source = 'caches/unit_test'
-    destination = '/home/olivier/scratch/caches/unit_test'
-    local_files = aws.s3_download_folder(source, destination)
+>>> source = 'caches/unit_test'
+... destination = '/home/olivier/scratch/caches/unit_test'
+... local_files = aws.s3_download_folder(source, destination)
 """
 from pathlib import Path
 import logging

--- a/one/remote/base.py
+++ b/one/remote/base.py
@@ -2,7 +2,7 @@
 
 All supported access protocols are defined in ALYX_JSON.
 
-Parameters:
+Remote parameters:
     - All parameters are stored in the .remote JSON file.
     - The base keys are access protocols (e.g. 'globus').
     - Each contains a map of ID to parameters (e.g. keys such as 'default', 'admin').

--- a/one/tests/alf/test_cache.py
+++ b/one/tests/alf/test_cache.py
@@ -132,6 +132,48 @@ class TestsONEParquet(unittest.TestCase):
         self.assertTrue(ses.index.nlevels == 1 and ses.index.name == 'id')
         self.assertTrue(dsets.index.nlevels == 2 and tuple(dsets.index.names) == ('eid', 'id'))
 
+    def test_remove_missing_datasets(self):
+        # Add a session that will only contains missing datasets
+        ghost_session = self.tmpdir.joinpath('lab', 'Subjects', 'sub', '2021-01-30', '001')
+        ghost_session.mkdir(parents=True)
+
+        tables = {
+            'sessions': apt._make_sessions_df(self.tmpdir),
+            'datasets': apt._make_datasets_df(self.tmpdir)
+        }
+
+        # Touch some files and folders for deletion
+        empty_missing_session = self.tmpdir.joinpath(self.rel_ses_path).parent.joinpath('003')
+        empty_missing_session.mkdir()
+        missing_dataset = self.tmpdir.joinpath(self.rel_ses_path).joinpath('foo.bar.npy')
+        missing_dataset.touch()
+        ghost_dataset = ghost_session.joinpath('foo.bar.npy')
+        ghost_dataset.touch()
+
+        # Test dry
+        to_remove = apt.remove_missing_datasets(
+            self.tmpdir, tables=tables, dry=True, remove_empty_sessions=False
+        )
+        self.assertTrue(all(map(Path.exists, to_remove)), 'Removed files during dry run!')
+        self.assertTrue(all(map(Path.is_file, to_remove)), 'Failed to ignore empty folders')
+        self.assertNotIn(empty_missing_session, to_remove, 'Failed to ignore empty folders')
+        self.assertNotIn(next(self.tmpdir.rglob('.invalid')), to_remove, 'Removed non-ALF file')
+
+        # Test removal of files and folders
+        removed = apt.remove_missing_datasets(
+            self.tmpdir, tables=tables, dry=False, remove_empty_sessions=True
+        )
+        self.assertTrue(sum(map(Path.exists, to_remove)) == 0, 'Failed to remove all files')
+        self.assertIn(empty_missing_session, removed, 'Failed to remove empty session folder')
+        self.assertIn(missing_dataset, removed, 'Failed to remove missing dataset')
+        self.assertIn(ghost_dataset, removed, 'Failed to remove missing dataset')
+        self.assertNotIn(ghost_session, removed, 'Removed empty session that was in session table')
+
+        # Check without tables input
+        apt.make_parquet_db(self.tmpdir, hash_ids=False)
+        removed = apt.remove_missing_datasets(self.tmpdir, dry=False)
+        self.assertTrue(len(removed) == 0)
+
     def tearDown(self) -> None:
         shutil.rmtree(self.tmpdir)
 

--- a/one/tests/remote/test_remote.py
+++ b/one/tests/remote/test_remote.py
@@ -440,5 +440,5 @@ class TestGlobusClient(unittest.TestCase):
             self.assertEqual('ERROR', log.records[-1].levelname)
 
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/one/tests/remote/test_remote_aws.py
+++ b/one/tests/remote/test_remote_aws.py
@@ -43,7 +43,7 @@ class TestAWSPublic(unittest.TestCase):
 
     def test_download_folder(self):
         """Test for one.remote.aws.s3_download_public_folder function."""
-        source = 'caches/openalyx'
+        source = 'caches/openalyx/2021_Q2_Varol_et_al'
         with tempfile.TemporaryDirectory() as td:
             destination = Path(td).joinpath('caches/unit_test')
             local_files = aws.s3_download_folder(source, destination)
@@ -104,3 +104,7 @@ class TestUtils(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             aws.get_s3_virtual_host('s3://my-s3-bucket/path/to/file', 'wrong-foo-4')
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -480,8 +480,8 @@ class TestDownloadHTTP(unittest.TestCase):
     def test_download_datasets(self):
         # test downloading a single file
         full_link_to_file = (
-            r'https://ibl.flatironinstitute.org/public/hoferlab/Subjects/SWC_043/'
-            '2020-09-21/001/alf/probes.trajectory.84116a5c-131e-40a2-92d4-62c4aaae5c52.json'
+            'https://ibl.flatironinstitute.org/public/mrsicflogellab/Subjects/SWC_038/'
+            '2020-07-29/001/alf/probes.description.f67570ac-1e54-4ce1-be5d-de2017a42116.json'
         )
         file_name, md5 = wc.http_download_file(full_link_to_file,
                                                return_md5=True, clobber=True)

--- a/one/tests/test_alyxrest.py
+++ b/one/tests/test_alyxrest.py
@@ -108,3 +108,7 @@ class Tests_REST(unittest.TestCase):
             })
         channels = one.alyx.rest('channels', 'create', data=channel_records)
         self.assertTrue(len(channels) == 3)
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -382,6 +382,17 @@ class TestAlyx2Path(unittest.TestCase):
         testable = converters.path_from_filerecord(fr, root_path='C:\\', uuid=uuid)
         self.assertTrue(uuid in testable.as_posix())
 
+    def test_session_record2path(self):
+        """Test for one.converters.session_record2path"""
+        rec = {'subject': 'ALK01', 'date': '2020-01-01', 'number': 1}
+        path = converters.session_record2path(rec)
+        self.assertEqual(path, PurePosixPath('ALK01/2020-01-01/001'))
+
+        rec = {'date': datetime.datetime.fromisoformat('2020-01-01').date(),
+               'number': '001', 'lab': 'foo', 'subject': 'ALK01'}
+        path = converters.session_record2path(rec, str(Path.home()))
+        self.assertEqual(path, Path.home() / 'foo/Subjects/ALK01/2020-01-01/001')
+
 
 class TestWrappers(unittest.TestCase):
     def test_recurse(self):

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -415,5 +415,5 @@ class TestWrappers(unittest.TestCase):
         self.assertIsInstance(wrapped([ref.copy(), expected], parse=True), list)
 
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1139,7 +1139,7 @@ class TestOneRemote(unittest.TestCase):
         self.one._cache['datasets'] = self.one._cache['datasets'].iloc[0:0].copy()
 
         dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
-        self.assertEqual(122, len(dsets))
+        self.assertEqual(108, len(dsets))
 
         # Test missing eid
         dsets = self.one.list_datasets('FMR019/2021-03-18/002', details=True, query_type='remote')
@@ -1155,7 +1155,7 @@ class TestOneRemote(unittest.TestCase):
         # Test details=False, with eid
         dsets = self.one.list_datasets(self.eid, details=False, query_type='remote')
         self.assertIsInstance(dsets, list)
-        self.assertEqual(122, len(dsets))
+        self.assertEqual(108, len(dsets))
 
         # Test with other filters
         dsets = self.one.list_datasets(self.eid, collection='*probe*', filename='*channels*',
@@ -1450,6 +1450,34 @@ class TestOneSetup(unittest.TestCase):
                 self.assertEqual(one_obj.alyx.base_url, TEST_DB_1['base_url'])
                 params_url = one.params.get(client=TEST_DB_1['base_url']).ALYX_URL
                 self.assertEqual(params_url, one_obj.alyx.base_url)
+
+    def test_setup_username(self):
+        """Test setting up parameters with a provided username.
+        - Mock getfile to return temp dir as param file location
+        - Mock input function as fail safe in case function erroneously prompts user for input
+        - Mock requests.post returns a fake user authentication response
+        """
+        credentials = {'username': 'foobar', 'password': '123'}
+        with mock.patch('iblutil.io.params.getfile', new=self.get_file),\
+                mock.patch('one.params.input', new=self.assertFalse),\
+                mock.patch('one.webclient.requests.post') as req_mock:
+            req_mock().json.return_value = {'token': 'shhh'}
+            # In remote mode the cache endpoint will not be queried
+            one_obj = ONE(base_url='https://test.alyx.internationalbrainlab.org',
+                          silent=True, mode='remote', **credentials)
+            params_username = one.params.get(client=TEST_DB_1['base_url']).ALYX_LOGIN
+            self.assertEqual(params_username, one_obj.alyx.user)
+            self.assertEqual(credentials['username'], one_obj.alyx.user)
+            self.assertEqual(req_mock.call_args.kwargs['data'], credentials)
+
+            # Reinstantiate as a different user
+            one_obj = ONE(base_url='https://test.alyx.internationalbrainlab.org',
+                          username='baz', password='123', mode='remote')
+            self.assertEqual(one_obj.alyx.user, 'baz')
+            self.assertEqual(one_obj.alyx.user, one_obj.alyx._par.ALYX_LOGIN)
+            # After initial set up the username in the pars file should remain unchanged
+            params_username = one.params.get(client=TEST_DB_1['base_url']).ALYX_LOGIN
+            self.assertNotEqual(one_obj.alyx.user, params_username)
 
     @unittest.skipIf(OFFLINE_ONLY, 'online only test')
     def test_static_setup(self):

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1298,7 +1298,7 @@ class TestOneDownload(unittest.TestCase):
         fr = [{'url': f'files/{self.fid}', 'json': None}]
         with mock.patch.object(self.one.alyx, '_generic_request', return_value=fr) as patched:
             self.one._download_dataset(rec, hash=file_hash)
-            args, kwargs = patched.call_args_list[-1]
+            args, kwargs = patched.call_args
             self.assertEqual(kwargs.get('data', {}), {'json': {'mismatch_hash': True}})
 
         # Check keep_uuid kwarg
@@ -1468,7 +1468,8 @@ class TestOneSetup(unittest.TestCase):
             params_username = one.params.get(client=TEST_DB_1['base_url']).ALYX_LOGIN
             self.assertEqual(params_username, one_obj.alyx.user)
             self.assertEqual(credentials['username'], one_obj.alyx.user)
-            self.assertEqual(req_mock.call_args.kwargs['data'], credentials)
+            _, kwargs = req_mock.call_args
+            self.assertEqual(kwargs.get('data', {}), credentials)
 
             # Reinstantiate as a different user
             one_obj = ONE(base_url='https://test.alyx.internationalbrainlab.org',

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -235,5 +235,5 @@ class TestRegistrationClient(unittest.TestCase):
         cls.temp_dir.cleanup()
 
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+    unittest.main(exit=False)

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -497,7 +497,7 @@ class AlyxClient():
             If true, auth token is cached
         """
         self.silent = silent
-        self._par = one.params.get(client=base_url, silent=self.silent)
+        self._par = one.params.get(client=base_url, silent=self.silent, username=username)
         self.base_url = base_url or self._par.ALYX_URL
         self._par = self._par.set('CACHE_DIR', cache_dir or self._par.CACHE_DIR)
         if username or password:
@@ -566,7 +566,12 @@ class AlyxClient():
             return
         if r.status_code == 403 and '"Invalid token."' in r.text:
             _logger.debug('Token invalid; Attempting to re-authenticate...')
-            self.authenticate(username=self.user, force=True)
+            # Log out in order to flush stale token.  At this point we no longer have the password
+            # but if the user re-instantiates with a password arg it will request a new token.
+            username = self.user
+            if self.silent:  # no need to log out otherwise; user will be prompted for password
+                self.logout()
+            self.authenticate(username=username, force=True)
             return self._generic_request(reqfunction, rest_query, data=data, files=files)
         else:
             _logger.debug('Response text: ' + r.text)

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -21,7 +21,7 @@ Create a subject
 ...     'death_date': None,
 ...     'lab': 'cortexlab',
 ... }
-... new_subj = alyx.rest('subjects', 'create', data=record)
+>>> new_subj = alyx.rest('subjects', 'create', data=record)
 
 Download a remote file, given a local path
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,6 +8,8 @@ sphinx-gallery
 ipyevents
 # ibllib  # Required to execute the one_quickstart notebook
 # matplotlib  # Required to execute the data_sharing notebook
+boto3  # For AWS module
+globus_sdk  # For Globus module
 
 # Also need to run
 # jupyter nbextension enable --py --sys-prefix ipyevents

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,7 +8,6 @@ sphinx-gallery
 ipyevents
 # ibllib  # Required to execute the one_quickstart notebook
 # matplotlib  # Required to execute the data_sharing notebook
-boto3  # For AWS module
 globus_sdk  # For Globus module
 
 # Also need to run


### PR DESCRIPTION
### Added

- function to remove cache files and folders that are not in datasets cache table

### Modified

- bugfix: load interpolate timestamps with timescale
- bugfix: username now passed to parameter setup routine
- in silent mode if token invalid the user is logged out to remove old token from param file
- root_dir now optional input for session_record2path
- do not check for recent cache upon instantiation in remote mode 