### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.14.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.15.0]
+
+### Modified
+
+- suppress irrelevant pandas future warning
+- ignore meta attribute when getting array length for interpolating timestamps in one.alf.io
+- no longer check for sizes if hash present
+- added yaml support to one.alf.io.load_file_content
+- added note of caution in download_dataset docstring
+
+## [1.14.0]
 
 ### Added
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.14.0'
+__version__ = '1.15.0'

--- a/one/alf/io.py
+++ b/one/alf/io.py
@@ -17,6 +17,7 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+import yaml
 
 from iblutil.util import Bunch
 from iblutil.io import parquet
@@ -311,6 +312,9 @@ def load_file_content(fil):
         return pd.read_csv(fil, delimiter=' ')
     if fil.suffix in ('.tsv', '.htsv'):
         return pd.read_csv(fil, delimiter='\t')
+    if fil.suffix in ('.yml', '.yaml'):
+        with open(fil, 'r') as _fil:
+            return yaml.safe_load(_fil)
     return Path(fil)
 
 
@@ -527,7 +531,8 @@ def load_object(alfpath, object=None, short_keys=False, **kwargs):
     timeseries = [k for k in out.keys() if 'timestamps' in k]
     if any(timeseries) and len(out.keys()) > len(timeseries) and status == 0:
         # Get length of one of the other arrays
-        n_samples = next(v for k, v in out.items() if 'timestamps' not in k).shape[0]
+        ignore = ('timestamps', 'meta')
+        n_samples = next(v for k, v in out.items() if not any(x in k for x in ignore)).shape[0]
         for key in timeseries:
             # Expand timeseries if necessary
             out[key] = ts2vec(out[key], n_samples)

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 import shutil
 import json
+import yaml
 
 import numpy as np
 import numpy.testing
@@ -494,6 +495,9 @@ class TestsLoadFile(unittest.TestCase):
             f.write('{"a": [1, 2, 3],"b": [4, 5 6]}')
         self.json3 = Path(self.tmpdir.name) / 'foo.baz.jsonable'
         jsonable.write(self.json3, {'a': [1, 2, 3], 'b': [4, 5, 6]})
+        self.yaml = Path(self.tmpdir.name) / 'foo.baz.yaml'
+        with open(self.yaml, 'w') as f:
+            f.write('{"a": [1, 2, 3],"b": [4, 5 6]}')
         self.xyz = Path(self.tmpdir.name) / 'foo.baz.xyz'
         with open(self.xyz, 'wb') as f:
             f.write(b'\x00\x00')
@@ -520,6 +524,9 @@ class TestsLoadFile(unittest.TestCase):
         file = alfio.load_file_content(str(self.xyz))
         self.assertEqual(file, self.xyz)
         self.assertIsNone(alfio.load_file_content(None))
+        # Load YAML file
+        loaded = alfio.load_file_content(str(self.yaml))
+        self.assertCountEqual(loaded.keys(), ['a', 'b'])
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -497,7 +497,7 @@ class TestsLoadFile(unittest.TestCase):
         jsonable.write(self.json3, {'a': [1, 2, 3], 'b': [4, 5, 6]})
         self.yaml = Path(self.tmpdir.name) / 'foo.baz.yaml'
         with open(self.yaml, 'w') as f:
-            f.write('{"a": [1, 2, 3],"b": [4, 5 6]}')
+            yaml.dump({'a': [1, 2, 3], 'b': [4, 5, 6]}, f)
         self.xyz = Path(self.tmpdir.name) / 'foo.baz.xyz'
         with open(self.xyz, 'wb') as f:
             f.write(b'\x00\x00')

--- a/one/tests/remote/test_remote.py
+++ b/one/tests/remote/test_remote.py
@@ -435,7 +435,6 @@ class TestGlobusClient(unittest.TestCase):
             self.client.mv('local', 'local', source, destination)
             warnings = filter(lambda x: x.levelno == 30, log.records)
             self.assertEqual(default_n_retries, len(list(warnings)))
-            self.assertIn(log.records[-1].msg)
             self.assertRegex(log.records[-1].msg, 'Max retries')
             self.assertEqual('ERROR', log.records[-1].levelname)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ requests>=2.22.0
 iblutil>=1.1.0
 packaging
 boto3
-yaml
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.22.0
 iblutil>=1.1.0
 packaging
 boto3
+yaml


### PR DESCRIPTION
### Modified

- suppress irrelevant pandas future warning
- ignore meta attribute when getting array length for interpolating timestamps in one.alf.io
- no longer check for sizes if hash present
- added yaml support to one.alf.io.load_file_content
- added note of caution in download_dataset docstring