### PR TITLE
V1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - local SSL config error causes ONE to fall back to local mode (as with other connection errors)
 - removed ref2dj method
 - one.util.ses2records now returns empty pandas DataFrame instead of None
+- fix download bug from OpenAlyx in remote mode
 
 ## [1.16.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.16.3]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.17.0]
+
+### Added
+
+- registration client checks for protected datasets and moves them to new revision when registering files 
+
+### Modified
+
+- local SSL config error causes ONE to fall back to local mode (as with other connection errors)
+
+## [1.16.3]
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Modified
 
 - local SSL config error causes ONE to fall back to local mode (as with other connection errors)
+- removed ref2dj method
+- one.util.ses2records now returns empty pandas DataFrame instead of None
 
 ## [1.16.3]
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -65,13 +65,12 @@ new_one = ONE().setup()  # Re-run setup for default database
 ```
 When prompted ('Enter the location of the download cache') enter the absolute path of the new download location.
 
-To **temporarily** change the download directory you can change the AlyxClient cache_dir attribute:
+To **temporarily** change the download directory, use the cache_dir arg:
 ```python
 from pathlib import Path
 from one.api import ONE
 
-one = ONE(base_url='https://alyx.example.com')
-one.alyx.cache_dir = Path.home() / 'new_download_dir'
+one = ONE(base_url='https://alyx.example.com', cache_dir=Path.home() / 'new_download_dir')
 ```
 
 ## How do check who I'm logged in as?

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.16.3'
+__version__ = '1.17.0'

--- a/one/converters.py
+++ b/one/converters.py
@@ -504,53 +504,6 @@ class ConversionMixin:
             ref = match.groupdict()
             return Bunch(ref) if as_dict else '{date:s}_{sequence:s}_{subject:s}'.format(**ref)
 
-    def ref2dj(self, ref: Union[str, Mapping, Iter]):
-        """
-        Return an ibl-pipeline sessions table, restricted by experiment reference(s)
-
-        Parameters
-        ----------
-        ref : str, list, dict
-            One or more objects with keys ('subject', 'date', 'sequence'), or strings with
-            the form yyyy-mm-dd_n_subject
-
-        Returns
-        -------
-        acquisition.Session
-            An acquisition.Session table corresponding to the ref
-
-        Examples
-        --------
-        >>> ref2dj('2020-06-20_2_CSHL046').fetch1()
-        Connecting...
-        {'subject_uuid': UUID('dffc24bc-bd97-4c2a-bef3-3e9320dc3dd7'),
-         'session_start_time': datetime.datetime(2020, 6, 20, 13, 31, 47),
-         'session_number': 2,
-         'session_date': datetime.date(2020, 6, 20),
-         'subject_nickname': 'CSHL046'}
-        >>> len(ref2dj({'date':'2020-06-20', 'sequence':'002', 'subject':'CSHL046'}))
-        1
-        >>> len(ref2dj(['2020-06-20_2_CSHL046', '2019-11-01_1_ibl_witten_13']))
-        2
-        """
-        from ibl_pipeline import subject, acquisition
-        sessions = acquisition.Session.proj('session_number',
-                                            session_date='date(session_start_time)')
-        sessions = sessions * subject.Subject.proj('subject_nickname')
-
-        ref = self.ref2dict(ref)  # Ensure dict-like
-
-        @recurse
-        def restrict(r):
-            date, sequence, subject = dict(sorted(r.items())).values()  # Unpack sorted
-            restriction = {
-                'subject_nickname': subject,
-                'session_number': sequence,
-                'session_date': date}
-            return restriction
-
-        return sessions & restrict(ref)
-
     @staticmethod
     def is_exp_ref(ref: Union[str, Mapping, Iter]) -> Union[bool, List[bool]]:
         """

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -274,22 +274,6 @@ class TestOnlineConverters(unittest.TestCase):
         path = self.one.record2path(rec[idx])
         self.assertEqual(expected, path)
 
-    def test_ref2dj(self):
-        """Test for ConversionMixin.ref2dj"""
-        try:
-            ref = '2020-09-21_1_SWC_043'
-            restriction = self.one.ref2dj(ref)
-        except ModuleNotFoundError:
-            self.skipTest('requires ibl_pipeline')
-        self.assertTrue(hasattr(restriction, 'fetch'))
-        expected = {
-            'subject_uuid': UUID('70bf8cbd-d312-4654-a4ea-3a21ea2f541b'),
-            'session_start_time': datetime.datetime(2020, 9, 21, 19, 2, 17),
-            'session_number': 1,
-            'session_date': datetime.date(2020, 9, 21),
-            'subject_nickname': 'SWC_043'}
-        self.assertEqual(restriction.fetch1(), expected)
-
     def test_eid2path(self):
         """Test for OneAlyx.eid2path"""
         verifiable = self.one.eid2path(self.eid, query_type='remote')

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1125,6 +1125,10 @@ class TestOneRemote(unittest.TestCase):
     def setUp(self) -> None:
         self.one = OneAlyx(**TEST_DB_2)
         self.eid = '4ecb5d24-f5cc-402c-be28-9d0f7cb14b3a'
+        # Set cache directory to a temp dir to ensure that we re-download files
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.one.alyx._par = self.one.alyx._par.set('CACHE_DIR', Path(self.tempdir.name))
 
     def test_online_repr(self):
         """Tests OneAlyx.__repr__"""

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -918,7 +918,7 @@ class TestOneAlyx(unittest.TestCase):
         # Check behaviour when no datasets present
         ses['data_dataset_session_related'] = []
         _, datasets = ses2records(ses)
-        self.assertIsNone(datasets)
+        self.assertTrue(datasets.empty)
 
     def test_datasets2records(self):
         """Test one.util.datasets2records"""
@@ -1139,7 +1139,7 @@ class TestOneRemote(unittest.TestCase):
         self.one._cache['datasets'] = self.one._cache['datasets'].iloc[0:0].copy()
 
         dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
-        self.assertEqual(108, len(dsets))
+        self.assertEqual(166, len(dsets))
 
         # Test missing eid
         dsets = self.one.list_datasets('FMR019/2021-03-18/002', details=True, query_type='remote')
@@ -1147,7 +1147,7 @@ class TestOneRemote(unittest.TestCase):
         self.assertEqual(len(dsets), 0)
 
         # Test empty datasets
-        with mock.patch('one.util.ses2records', return_value=(None, None)):
+        with mock.patch('one.util.ses2records', return_value=(pd.DataFrame(), pd.DataFrame())):
             dsets = self.one.list_datasets(self.eid, details=True, query_type='remote')
             self.assertIsInstance(dsets, pd.DataFrame)
             self.assertEqual(len(dsets), 0)
@@ -1155,12 +1155,12 @@ class TestOneRemote(unittest.TestCase):
         # Test details=False, with eid
         dsets = self.one.list_datasets(self.eid, details=False, query_type='remote')
         self.assertIsInstance(dsets, list)
-        self.assertEqual(108, len(dsets))
+        self.assertEqual(166, len(dsets))
 
         # Test with other filters
         dsets = self.one.list_datasets(self.eid, collection='*probe*', filename='*channels*',
                                        details=False, query_type='remote')
-        self.assertEqual(13, len(dsets))
+        self.assertEqual(20, len(dsets))
         self.assertTrue(all(x in y for x in ('probe', 'channels') for y in dsets))
 
         with self.assertWarns(Warning):
@@ -1182,7 +1182,7 @@ class TestOneRemote(unittest.TestCase):
         eids = self.one.search(subject='SWC_043', dataset=['probes.description'], number=1,
                                django='data_dataset_session_related__collection__iexact,alf',
                                query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        self.assertIn(self.eid, list(eids))
 
         # Test date range
         eids = self.one.search(subject='SWC_043', date='2020-09-21', query_type='remote')
@@ -1341,7 +1341,7 @@ class TestOneDownload(unittest.TestCase):
             self.assertIsNone(file)
 
         rec = self.one.list_datasets(self.eid, details=True)
-        rec = rec[rec.rel_path.str.contains('pykilosort/channels.brainLocation')]
+        rec = rec[rec.rel_path.str.contains('00/pykilosort/channels.brainLocation')]
         rec['exists_aws'] = False  # Ensure we use FlatIron for this
         files = self.one._download_datasets(rec)
         self.assertFalse(None in files)

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -319,7 +319,8 @@ class TestRegistrationClient(unittest.TestCase):
             [x.touch() for x in files]
             self.client.register_files(file_list=files)
             self.assertEqual(2, alyx_mock.call_count)
-            actual = alyx_mock.call_args.kwargs.get('data', {}).get('filenames', [])
+            _, kwargs = alyx_mock.call_args
+            actual = kwargs.get('data', {}).get('filenames', [])
             expected = [
                 'wheel.position.ssv',
                 f'#{today}#/wheel.position.npy',

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -267,14 +267,15 @@ class TestRegistrationClient(unittest.TestCase):
         # Protect the latest datasets
         self.one.alyx.rest('datasets', 'partial_update', id=r2['id'], data={'tags': [tag]})
         # Same day revision
+        today = datetime.date.today()
         r, = self.client.register_files(file_list=[file])
-        self.assertEqual(r['revision'], str(datetime.date.today()) + 'a')
+        self.assertEqual(r['revision'], f'{today}a')
         self.assertTrue(file.parents[1].joinpath(f'#{r["revision"]}#', file.name).exists())
         self.assertFalse(file.exists(), 'failed to move protected dataset to new revision')
 
         # Re-register a protected date; given original and revision a are protected
         # we expect to create revision b
-        file = session_path.joinpath(f'#{datetime.date.today()}#', file_name.name)
+        file = session_path.joinpath(f'#{today}#', file_name.name)
         file.touch()
         self.one.alyx.rest('datasets', 'partial_update', id=r['id'], data={'tags': [tag]})
         r, = self.client.register_files(file_list=[file])
@@ -292,16 +293,16 @@ class TestRegistrationClient(unittest.TestCase):
                                 {'puHIt1': True}]},
                             # Dataset protected but latest (date) revision is unprotected
                             {'wheel.position.npy': [
-                                {'2023-01-10': False},
+                                {f'{today}': False},
                                 {'puHIt1': True}]},
                             # Dataset protected and latest (date) revision is today
                             {'wheel.timestamps.npy': [
-                                {str(datetime.date.today()): True},
+                                {str(today): True},
                                 {'puHIt1': True}]},
                             # Dataset protected and latest (date) revision was updated twice
                             {'wheel.timestamps.ssv': [
-                                {f'{datetime.date.today()}a': True},
-                                {str(datetime.date.today()): True}]},
+                                {f'{today}a': True},
+                                {str(today): True}]},
                             # Dataset protected but latest (misc) revision not protected
                             {'wheel.velocity.ssv': [
                                 {'puHIt1': False},
@@ -309,8 +310,8 @@ class TestRegistrationClient(unittest.TestCase):
                             # Dataset protected and latest (date) revision end with a different
                             # character
                             {'wheel.velocity.npy': [
-                                {f'{datetime.date.today()}A': True},
-                                {str(datetime.date.today()): True}]},
+                                {f'{today}A': True},
+                                {str(today): True}]},
                         ]}
             mock_resp._content = bytes(json.dumps(response), 'utf-8')
             alyx_mock.side_effect = [HTTPError(response=mock_resp), [{}]]
@@ -321,11 +322,11 @@ class TestRegistrationClient(unittest.TestCase):
             actual = alyx_mock.call_args.kwargs.get('data', {}).get('filenames', [])
             expected = [
                 'wheel.position.ssv',
-                f'#{datetime.date.today()}#/wheel.position.npy',
-                f'#{datetime.date.today()}a#/wheel.timestamps.npy',
-                f'#{datetime.date.today()}b#/wheel.timestamps.ssv',
-                f'#{datetime.date.today()}#/wheel.velocity.ssv',
-                f'#{datetime.date.today()}B#/wheel.velocity.npy']
+                f'#{today}#/wheel.position.npy',
+                f'#{today}a#/wheel.timestamps.npy',
+                f'#{today}b#/wheel.timestamps.ssv',
+                f'#{today}#/wheel.velocity.ssv',
+                f'#{today}B#/wheel.velocity.npy']
             self.assertEqual(expected, actual)
 
             # Finally, simply check that the exception is re-raised for non-revision related errors

--- a/one/util.py
+++ b/one/util.py
@@ -64,7 +64,7 @@ def ses2records(ses: dict, int_id=False):
             rec['id'] = d['id']
             rec['eid'] = session.name
         file_path = urllib.parse.urlsplit(d['data_url'], allow_fragments=False).path.strip('/')
-        file_path = alfio.remove_uuid_file(file_path, dry=True).as_posix()
+        file_path = get_alf_path(alfio.remove_uuid_file(file_path, dry=True))
         rec['session_path'] = get_session_path(file_path).as_posix()
         rec['rel_path'] = file_path[len(rec['session_path']):].strip('/')
         rec['default_revision'] = d['default_revision'] == 'True'

--- a/one/util.py
+++ b/one/util.py
@@ -71,7 +71,7 @@ def ses2records(ses: dict, int_id=False):
         return rec
 
     if not ses.get('data_dataset_session_related'):
-        return session, None
+        return session, pd.DataFrame()
     records = map(_to_record, ses['data_dataset_session_related'])
     index = ['eid_0', 'eid_1', 'id_0', 'id_1'] if int_id else ['eid', 'id']
     datasets = pd.DataFrame(records).set_index(index).sort_index()


### PR DESCRIPTION
## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.17.0]

### Added

- registration client checks for protected datasets and moves them to new revision when registering files 

### Modified

- local SSL config error causes ONE to fall back to local mode (as with other connection errors)