### PR TITLE
V1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - RegistrationClient.find_files is now itself a generator method (previously returned a generator)
 - exists kwarg in RegistrationClient.register_files
+- Support for loading 'table' attribute as dataframe with extra ALF parts
 
 ## [1.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.17.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.18.0]
+
+### Added
+
+- one.registration.get_dataset_type function for validating a dataset type
+
+### Modified
+
+- RegistrationClient.find_files is now itself a generator method (previously returned a generator)
+- exists kwarg in RegistrationClient.register_files
+
+## [1.17.0]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - RegistrationClient.find_files is now itself a generator method (previously returned a generator)
 - exists kwarg in RegistrationClient.register_files
 - Support for loading 'table' attribute as dataframe with extra ALF parts
+- bugfix: tag assertion should expect list of tags in cache info
 
 ## [1.17.0]
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.17.0'
+__version__ = '1.18.0'

--- a/one/api.py
+++ b/one/api.py
@@ -1457,7 +1457,7 @@ class OneAlyx(One):
         try:
             # Determine whether a newer cache is available
             cache_info = self.alyx.get(f'cache/info/{tag or ""}'.strip('/'), expires=True)
-            assert tag == cache_info.get('database_tags')
+            assert tag is None or tag in cache_info.get('database_tags', [])
 
             # Check version compatibility
             min_version = packaging.version.parse(cache_info.get('min_api_version', '0.0.0'))

--- a/one/registration.py
+++ b/one/registration.py
@@ -418,7 +418,7 @@ class RegistrationClient:
         created_by : str
             Name of Alyx user (defaults to whoever is logged in to ONE instance).
         server_only : bool
-            Will only create file records in the 'online' repositories and skips local repositories.
+            Will only create file records in the 'online' repositories and skips local repositories
         repository : str
             Name of the repository in Alyx to register to.
         exists : bool

--- a/one/remote/aws.py
+++ b/one/remote/aws.py
@@ -203,7 +203,7 @@ def s3_download_file(source, destination, s3=None, bucket_name=None, overwrite=F
                   unit_scale=True, desc=str(destination)) as t:
             file_object.download_file(Filename=str(destination), Callback=_callback_hook(t))
     except (NoCredentialsError, PartialCredentialsError) as ex:
-        raise ex  # Credentials need updating in Alyx
+        raise ex  # Credentials need updating in Alyx # pragma: no cover
     except ClientError as ex:
         if ex.response.get('Error', {}).get('Code', None) == '404':
             _logger.error(f'File {source} not found on {bucket_name}')

--- a/one/remote/base.py
+++ b/one/remote/base.py
@@ -122,17 +122,17 @@ class DownloadClient:
     @abstractmethod
     def to_address(self, data_path, *args, **kwargs):
         """Returns the remote data URL for a given ALF path"""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def download_file(self, file_address):
         """Download an ALF dataset given its address"""
-        pass
+        pass  # pragma: no cover
 
     @staticmethod
     @abstractmethod
     def setup(*args, **kwargs):
-        pass
+        pass  # pragma: no cover
 
     @staticmethod
     def repo_from_alyx(name, alyx):

--- a/one/remote/globus.py
+++ b/one/remote/globus.py
@@ -273,14 +273,14 @@ class Globus(DownloadClient):
         self.endpoints['local']['root_path'] = self.pars.local_path
 
     def to_address(self, data_path, endpoint):
-        pass
+        pass  # pragma: no cover
 
     def download_file(self, file_address):
-        pass
+        pass  # pragma: no cover
 
     @staticmethod
     def setup(*args, **kwargs):
-        pass
+        pass  # pragma: no cover
 
     def add_endpoint(self, endpoint, label=None, root_path=None, overwrite=False, alyx=None):
         """

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -382,6 +382,13 @@ class TestsAlf(unittest.TestCase):
         self.assertNotIn('table', new_obj)
         np.testing.assert_array_equal(new_obj['baz'], obj['baz'],
                                       'Table attribute should take precedent')
+        # Check behaviour loading table with long keys / extra ALF parts
+        table_file = next(self.tmpdir.glob('*table*'))
+        new_name = table_file.stem + '_clock.extra' + table_file.suffix
+        table_file.rename(table_file.parent.joinpath(new_name))
+        new_obj = alfio.load_object(self.tmpdir, 'obj')
+        expected = ['baz', 'baz_clock.extra', 'bar_clock.extra', 'foo_clock.extra']
+        self.assertCountEqual(expected, new_obj.keys())
 
     def test_ls(self):
         """Test for one.alf.io._ls"""

--- a/one/tests/remote/test_remote_aws.py
+++ b/one/tests/remote/test_remote_aws.py
@@ -40,6 +40,12 @@ class TestAWSPublic(unittest.TestCase):
             with self.assertLogs('one.remote.aws', logging.ERROR) as lg:
                 self.assertIsNone(aws.s3_download_file('foo/bar/baz.BAT', destination))
                 self.assertIn('not found', lg.output[-1])
+            # Test other client errors re-raised
+            with mock.patch('one.remote.aws.get_s3_public') as s3_mock:
+                m = mock.MagicMock()
+                s3_mock.return_value = (m, m)
+                m.Object.side_effect = aws.ClientError(mock.MagicMock(), mock.MagicMock())
+                self.assertRaises(aws.ClientError, aws.s3_download_file, '', destination)
 
     def test_download_folder(self):
         """Test for one.remote.aws.s3_download_public_folder function."""

--- a/one/tests/test_alyxrest.py
+++ b/one/tests/test_alyxrest.py
@@ -110,5 +110,5 @@ class Tests_REST(unittest.TestCase):
         self.assertTrue(len(channels) == 3)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(exit=False)

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -9,7 +9,6 @@ import datetime
 import fnmatch
 from io import StringIO
 from pathlib import Path
-from functools import partial
 
 from iblutil.util import Bunch
 from requests.exceptions import HTTPError

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -9,6 +9,7 @@ import datetime
 import fnmatch
 from io import StringIO
 from pathlib import Path
+from functools import partial
 
 from iblutil.util import Bunch
 from requests.exceptions import HTTPError
@@ -22,9 +23,35 @@ from . import TEST_DB_1, OFFLINE_ONLY
 from one.tests import util
 
 
+class TestDatasetTypes(unittest.TestCase):
+    """Tests for dataset type validation."""
+    def test_get_dataset_type(self):
+        """Test one.registration.get_dataset_type function."""
+        dtypes = [
+            {'name': 'obj.attr', 'filename_pattern': ''},
+            {'name': 'foo.bar', 'filename_pattern': '*FOO.b?r*'},
+            {'name': 'bar.baz', 'filename_pattern': ''},
+            {'name': 'some_file', 'filename_pattern': 'some_file.*'}
+        ]
+        dtypes = list(map(Bunch, dtypes))
+        filename_typename = (
+            ('foo.bar.npy', 'foo.bar'), ('foo.bir.npy', 'foo.bar'),
+            ('_ns_obj.attr_clock.extra.npy', 'obj.attr'),
+            ('bar.baz.ext', 'bar.baz'), ('some_file.ext', 'some_file'))
+        for filename, dataname in filename_typename:
+            with self.subTest(filename=filename):
+                dtype = registration.get_dataset_type(filename, dtypes)
+                self.assertEqual(dtype.name, dataname)
+
+        self.assertRaises(ValueError, registration.get_dataset_type, 'no_match', dtypes)
+        # Add an ambiguous dataset type pattern
+        dtypes.append(Bunch({'name': 'foo.bor', 'filename_pattern': 'foo.bor*'}))
+        self.assertRaises(ValueError, registration.get_dataset_type, 'foo.bor', dtypes)
+
+
 @unittest.skipIf(OFFLINE_ONLY, 'online only test')
 class TestRegistrationClient(unittest.TestCase):
-    """Test class for RegistrationClient class"""
+    """Test class for RegistrationClient class."""
     one = None
     subject = None
     temp_dir = None
@@ -366,5 +393,5 @@ class TestRegistrationClient(unittest.TestCase):
         cls.temp_dir.cleanup()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(exit=False)

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -460,7 +460,7 @@ def dataset_record_to_url(dataset_record) -> list:
     return urls
 
 
-class AlyxClient():
+class AlyxClient:
     """
     Class that implements simple GET/POST wrappers for the Alyx REST API.
     See https://openalyx.internationalbrainlab.org/docs


### PR DESCRIPTION
## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.18.0]

### Added

- `one.registration.get_dataset_type` function for validating a dataset type

### Modified

- `RegistrationClient.find_files` is now itself a generator method (previously returned a generator)
- exists kwarg in `RegistrationClient.register_files`
- Support for loading 'table' attribute as dataframe with extra ALF parts
- bugfix: tag assertion should expect list of tags in cache info
