### PR TITLE
Remove redundant method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.18.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) []
+
+### Added
+
+- one.registration.get_dataset_type function for validating a dataset type
+
+### Removed
+
+- removed RegistrationClient.create_session, use register_session method instead
+
+### Modified
+
+- ensure AlyxClient.is_logged_in returns boolean
+
+## [1.18.0]
 
 ### Added
 
@@ -9,7 +23,7 @@
 
 - RegistrationClient.find_files is now itself a generator method (previously returned a generator)
 - exists kwarg in RegistrationClient.register_files
-- Support for loading 'table' attribute as dataframe with extra ALF parts
+- support for loading 'table' attribute as dataframe with extra ALF parts
 - bugfix: tag assertion should expect list of tags in cache info
 
 ## [1.17.0]
@@ -18,10 +32,13 @@
 
 - registration client checks for protected datasets and moves them to new revision when registering files 
 
+### Removed
+
+- removed ref2dj method
+
 ### Modified
 
 - local SSL config error causes ONE to fall back to local mode (as with other connection errors)
-- removed ref2dj method
 - one.util.ses2records now returns empty pandas DataFrame instead of None
 - fix download bug from OpenAlyx in remote mode
 
@@ -325,8 +342,11 @@
 
 ## [1.0.0]
 
-### Modified
+### Removed
+
 - removed deprecated `_from_` converters
+
+### Modified
 - removed walrus from test
 - raise warning when fails to set dataset exists to False
 
@@ -368,12 +388,15 @@
 - function to convert datasets list endpoint to DataFrame
 - added logout method; 'authenticate' now prompts for Alyx password if none provided and no token
 
+### Removed
+
+- ALYX_PWD field removed from setup
+
 ### Modified
 
 - fully adopted Numpy docstrings
 - revisions now filtered using <= instead of <
 - datasets_from_type now type2datasets; returns similar output to list_ methods
-- removed ALYX_PWD from setup
 - webclient functions sdsc_globus_path_from_dataset, sdsc_path_from_dataset and globus_path_from_dataset moved to ibllib
 
 ## [0.2.3]
@@ -438,13 +461,13 @@
 
 - refactored load methods to use the same filter functions
 
-## 0.1.3
+## [0.1.3]
 
 ### Added
 
 - a load_datasets method for loading multiple datasets at once
 
-## 0.1.2
+## [0.1.2]
 
 ### Modified
 
@@ -452,14 +475,14 @@
  - fix to download_dataset error with alyx record; tests added
  - api utils moved to new module
 
-## 0.1.1
+## [0.1.1]
 
 ### Modified
 
  - fix setting default ALYX_URL in setup
  - fix for updating missing records in cache
 
-## 0.1.0
+## [0.1.0]
 
 ### Added
 
@@ -468,10 +491,13 @@
  - silent mode now suppresses print statements
  - rest GET requests are now cached for 24 hours
  - alf.spec module for constructing, documenting, and validating ALyx Files
+
+### Removed
+
+ - removed load method
  
 ### Modified
 
- - removed load method
  - support for multiple configured databases in params
  - Alyx web token now cached between sessions
  - delayed loading of rest schemes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) []
-
-### Added
-
-- one.registration.get_dataset_type function for validating a dataset type
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.0]
 
 ### Removed
 
@@ -12,6 +8,7 @@
 ### Modified
 
 - ensure AlyxClient.is_logged_in returns boolean
+- bugfix: RegistrationClient.register_files uses get_dataset_type for validating input file list
 
 ## [1.18.0]
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.18.0'
+__version__ = '1.19.0'

--- a/one/registration.py
+++ b/one/registration.py
@@ -79,10 +79,10 @@ def get_dataset_type(filename, dtypes):
             dataset_types.append(dt)
     n = len(dataset_types)
     if n == 0:
-        raise ValueError(f'No dataset type found for filename "{filename}"')
+        raise ValueError(f'No dataset type found for filename "{filename.name}"')
     elif n >= 2:
         raise ValueError('Multiple matching dataset types found for filename '
-                         f'"{filename}": {", ".join(map(str, dataset_types))}')
+                         f'"{filename.name}": \n{", ".join(map(str, dataset_types))}')
     return dataset_types[0]
 
 
@@ -457,14 +457,10 @@ class RegistrationClient:
             if fn.suffix not in self.file_extensions:
                 _logger.debug(f'{fn}: No matching extension "{fn.suffix}" in database')
                 continue
-            type_match = [x['name'] for x in self.dtypes
-                          if fnmatch(fn.name, x['filename_pattern'] or '')]
-            if len(type_match) == 0:
-                _logger.debug(f'{fn}: No matching dataset type in database')
-                continue
-            elif len(type_match) != 1:
-                _logger.debug(f'{fn}: Multiple matching dataset types in database\n'
-                              '"' + '", "'.join(type_match) + '"')
+            try:
+                get_dataset_type(fn, self.dtypes)
+            except ValueError as ex:
+                _logger.debug('%s', ex.args[0])
                 continue
             F[session_path].append(fn.relative_to(session_path))
             V[session_path].append(ver)

--- a/one/registration.py
+++ b/one/registration.py
@@ -6,7 +6,6 @@ and registering associated datasets.
 Summary of methods
 ------------------
 create_new_session - Create a new local session folder and optionally create session record on Alyx
-create_session - Create session record on Alyx from local path, without registering files
 create_sessions - Create sessions and register files for folder containing a given flag file
 register_session - Create a session on Alyx from local path and register any ALF datasets present
 register_files - Register a list of files to their respective sessions on Alyx
@@ -101,7 +100,8 @@ class RegistrationClient:
         self.file_extensions = [df['file_extension'] for df in
                                 self.one.alyx.rest('data-formats', 'list', no_cache=True)]
 
-    def create_sessions(self, root_data_folder, glob_pattern='**/create_me.flag', dry=False):
+    def create_sessions(self, root_data_folder, glob_pattern='**/create_me.flag',
+                        register_files=False, dry=False):
         """
         Create sessions looking recursively for flag files.
 
@@ -111,6 +111,8 @@ class RegistrationClient:
             Folder to look for sessions.
         glob_pattern : str
             Register valid sessions that contain this pattern.
+        register_files : bool
+            If true, register all valid datasets within the session folder.
         dry : bool
             If true returns list of sessions without creating them on Alyx.
 
@@ -129,26 +131,10 @@ class RegistrationClient:
                 continue
             _logger.info('creating session for ' + str(flag_file.parent))
             # providing a false flag stops the registration after session creation
-            records.append(self.create_session(flag_file.parent))
+            session_info, _ = self.register_session(flag_file.parent, file_list=register_files)
+            records.append(session_info)
             flag_file.unlink()
         return [ff.parent for ff in flag_files], records
-
-    def create_session(self, session_path, **kwargs) -> dict:
-        """Create a remote session on Alyx from a local session path, without registering files.
-
-        Parameters
-        ----------
-        session_path : str, pathlib.Path
-            The path ending with subject/date/number.
-        **kwargs
-            Optional arguments for RegistrationClient.register_session.
-
-        Returns
-        -------
-        dict
-            Newly created session record.
-        """
-        return self.register_session(session_path, file_list=False, **kwargs)[0]
 
     def create_new_session(self, subject, session_root=None, date=None, register=True, **kwargs):
         """Create a new local session folder and optionally create session record on Alyx.
@@ -195,7 +181,11 @@ class RegistrationClient:
         session_root = Path(session_root or self.one.alyx.cache_dir) / subject / date[:10]
         session_path = session_root / alfio.next_num_folder(session_root)
         session_path.mkdir(exist_ok=True, parents=True)  # Ensure folder exists on disk
-        eid = UUID(self.create_session(session_path, **kwargs)['url'][-36:]) if register else None
+        if register:
+            session_info, _ = self.register_session(session_path, **kwargs)
+            eid = UUID(session_info['url'][-36:])
+        else:
+            eid = None
         return session_path, eid
 
     def find_files(self, session_path):

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -86,7 +86,7 @@ class TestAuthentication(unittest.TestCase):
         """Test behaviour when calling AlyxClient._generic_request when logged out"""
         # Check that authentication happens when making a logged out request
         self.ac.logout()
-        assert not self.ac.is_logged_in
+        assert self.ac.is_logged_in is False
         # Set pars for auto login
         login_keys = {'ALYX_LOGIN', 'ALYX_PWD'}
         if not set(self.ac._par.as_dict().keys()) >= login_keys:
@@ -105,7 +105,7 @@ class TestAuthentication(unittest.TestCase):
 
         # Test download cache tables
         self.ac.logout()
-        assert not self.ac.is_logged_in
+        self.assertFalse(self.ac.is_logged_in)
         url = self.ac.get('cache/info')['location']
         self.ac.download_cache_tables(url)
         self.assertTrue(self.ac.is_logged_in)

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -958,8 +958,9 @@ class TestOneAlyx(unittest.TestCase):
     def test_describe_revision(self, mock_stdout):
         """Test OneAlyx.describe_revision"""
         self.one.mode = 'remote'
+        # Choose a date in the past so as to not conflict with registration tests
         record = {
-            'name': str(datetime.date.today()) + 'a',
+            'name': str(datetime.date.today() - datetime.timedelta(days=5)) + 'a',
             'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
         }
         try:

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -249,8 +249,8 @@ class TestRegistrationClient(unittest.TestCase):
         with self.assertLogs('one.registration', logging.DEBUG) as dbg:
             rec = self.client.register_files(files, versions=version)
             self.assertIn('wheel.position.xxx: No matching extension', dbg.records[0].message)
-            self.assertIn('foo.bar.npy: No matching dataset type', dbg.records[1].message)
-            self.assertIn(f'{ambiguous}: Multiple matching', dbg.records[2].message)
+            self.assertRegex(dbg.records[1].message, 'No dataset type .* "foo.bar.npy"')
+            self.assertRegex(dbg.records[2].message, f'Multiple matching .* "{ambiguous}"')
         self.assertFalse(len(rec))
 
         # Check the handling of revisions

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -466,7 +466,7 @@ class AlyxClient:
     See https://openalyx.internationalbrainlab.org/docs
     """
     _token = None
-    _headers = None  # Headers for REST requests only
+    _headers = {}  # Headers for REST requests only
     """str: The Alyx username"""
     user = None
     """str: The Alyx database URL"""
@@ -504,7 +504,7 @@ class AlyxClient:
             self.authenticate(username, password)
         self._rest_schemes = None
         # the mixed accept application may cause errors sometimes, only necessary for the docs
-        self._headers = {**(self._headers or {}), 'Accept': 'application/json'}
+        self._headers = {**self._headers, 'Accept': 'application/json'}
         # REST cache parameters
         # The default length of time that cache file is valid for,
         # The default expiry is overridden by the `expires` kwarg.  If False, the caching is
@@ -529,7 +529,7 @@ class AlyxClient:
     @property
     def is_logged_in(self):
         """bool: Check if user logged into Alyx database; True if user is authenticated"""
-        return self._token and self.user and self._headers and 'Authorization' in self._headers
+        return bool(self.user and self._token and 'Authorization' in self._headers)
 
     def list_endpoints(self):
         """


### PR DESCRIPTION
## [1.19.0]

### Removed

- removed `RegistrationClient.create_session`, use register_session method instead

### Modified

- ensure `AlyxClient.is_logged_in` returns boolean
- bugfix: `RegistrationClient.register_files` uses get_dataset_type for validating input file list