### PR TITLE
HOTFIX: allow kwargs in RegistrationClient.register_files to explicit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.1]
+
+### Modified
+
+- HOTFIX: allow kwargs in RegistrationClient.register_files to explicitly pass in lab name(s)
+
+## [1.19.0]
 
 ### Removed
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.19.0'
+__version__ = '1.19.1'

--- a/one/registration.py
+++ b/one/registration.py
@@ -393,7 +393,7 @@ class RegistrationClient:
 
     def register_files(self, file_list,
                        versions=None, default=True, created_by=None, server_only=False,
-                       repository=None, exists=True, dry=False, max_md5_size=None):
+                       repository=None, exists=True, dry=False, max_md5_size=None, **kwargs):
         """
         Registers a set of files belonging to a session only on the server.
 
@@ -420,6 +420,8 @@ class RegistrationClient:
         exists : bool
             Whether files exist in the repository. May be set to False when registering files
             before copying to the repository.
+        **kwargs
+            Extra arguments directly passed as REST request data to /register-files endpoint.
 
         Returns
         -------
@@ -490,11 +492,12 @@ class RegistrationClient:
                   'server_only': server_only,
                   'default': default,
                   'versions': V[session_path],
-                  'check_protected': True
+                  'check_protected': True,
+                  **kwargs
                   }
 
             # Add optional field
-            if details['lab']:
+            if details['lab'] and not kwargs.get('labs'):
                 r_['labs'] = details['lab']
             # If dry, store POST data, otherwise store resulting file records
             try:

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -230,10 +230,12 @@ class TestRegistrationClient(unittest.TestCase):
         # Check registering single file, dry run, default False
         file_name = session_path.joinpath('wheel.position.npy')
         file_name.touch()
-        rec = self.client.register_files(str(file_name), default=False, dry=True)
+        labs = 'mainenlab,cortexlab'
+        rec = self.client.register_files(str(file_name), default=False, dry=True, labs=labs)
         self.assertIsInstance(rec, dict)
         self.assertFalse(rec['default'])
         self.assertNotIn('id', rec)
+        self.assertEqual(labs, rec['labs'], 'failed to include optional kwargs in request')
 
         # Add ambiguous dataset type to types list
         self.client.dtypes.append(self.client.dtypes[-1].copy())


### PR DESCRIPTION
…ly pass in lab name(s)