### PR TITLE
1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.1]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.2]
+
+### Modified
+
+- HOTFIX: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name 
+
+## [1.19.1]
 
 ### Modified
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.19.1'
+__version__ = '1.19.2'

--- a/one/api.py
+++ b/one/api.py
@@ -1674,7 +1674,7 @@ class OneAlyx(One):
             if field == 'date_range':
                 params[field] = [x.date().isoformat() for x in util.validate_date_range(value)]
             elif field == 'dataset':
-                query = ('data_dataset_session_related__dataset_type__name__icontains,' +
+                query = ('data_dataset_session_related__name__icontains,' +
                          ','.join(util.ensure_list(value)))
                 params['django'] += (',' if params['django'] else '') + query
             elif field == 'laboratory':

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1193,9 +1193,11 @@ class TestOneRemote(unittest.TestCase):
         eids = self.one.search(subject='SWC_043', date='2020-09-21', query_type='remote')
         self.assertCountEqual(eids, [self.eid])
 
-        eids = self.one.search(date=[datetime.date(2020, 9, 21), datetime.date(2020, 9, 22)],
-                               lab='hoferlab', query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        date_range = [datetime.date(2020, 9, 21), datetime.date(2020, 9, 22)]
+        eids = self.one.search(date=date_range, lab='hoferlab', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+        dates = set(map(lambda x: self.one.get_details(x)['date'], eids))
+        self.assertTrue(dates <= set(date_range))
 
         # Test limit arg and LazyId
         eids = self.one.search(date='2020-03-23', limit=2, query_type='remote')
@@ -1207,6 +1209,17 @@ class TestOneRemote(unittest.TestCase):
         self.assertIn(self.eid, list(eids))
 
         eids = self.one.search(lab='hoferlab', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+
+        # Test dataset and dataset_types kwargs
+        eids = self.one.search(dataset='trials.table.pqt', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+        eids = self.one.search(dataset='trials.intervals.npy', query_type='remote')
+        self.assertNotIn(self.eid, list(eids))
+
+        eids = self.one.search(dataset_type='trials.table.pqt', query_type='remote')
+        self.assertEqual(0, len(eids))
+        eids = self.one.search(dataset_type='trials.table', date='2020-09-21', query_type='remote')
         self.assertIn(self.eid, list(eids))
 
     def test_load_dataset(self):

--- a/one/util.py
+++ b/one/util.py
@@ -342,6 +342,12 @@ def filter_datasets(all_datasets, filename=None, collection=None, revision=None,
     Filter by filename parts
 
     >>> datasets = filter_datasets(all_datasets, dict(object='spikes', attribute='times'))
+
+    Notes
+    -----
+    - It is not possible to match datasets that are in a given collection OR NOT in ANY collection.
+     e.g. filter_datasets(dsets, collection=['alf', '']) will not match the latter. For this you
+     must use two separate queries.
     """
     # Create a regular expression string to match relative path against
     filename = filename or {}

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -1104,17 +1104,17 @@ class AlyxClient:
         Examples
         --------
         >>> client = AlyxClient()
-        >>> client.json_field_update("sessions", "eid_str", "extended_qc", {"key": "value"})
+        >>> client.json_field_update('sessions', 'eid_str', 'extended_qc', {'key': 'value'})
         """
         self._check_inputs(endpoint)
         # Load current json field contents
-        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        current = self.rest(endpoint, 'read', id=uuid)[field_name]
         if current is None:
             current = {}
 
         if not isinstance(current, dict):
             _logger.warning(
-                f"Current json field {field_name} does not contains a dict, aborting update"
+                f'Current json field {field_name} does not contains a dict, aborting update'
             )
             return current
 
@@ -1123,7 +1123,7 @@ class AlyxClient:
         # Prepare data to patch
         patch_dict = {field_name: current}
         # Upload new extended_qc to session
-        ret = self.rest(endpoint, "partial_update", id=uuid, data=patch_dict)
+        ret = self.rest(endpoint, 'partial_update', id=uuid, data=patch_dict)
         return ret[field_name]
 
     def json_field_remove_key(
@@ -1154,18 +1154,18 @@ class AlyxClient:
             New content of json field
         """
         self._check_inputs(endpoint)
-        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        current = self.rest(endpoint, 'read', id=uuid)[field_name]
         # If no contents, cannot remove key, return
         if current is None:
             return current
         # if contents are not dict, cannot remove key, return contents
         if isinstance(current, str):
-            _logger.warning(f"Cannot remove key {key} content of json field is of type str")
+            _logger.warning(f'Cannot remove key {key} content of json field is of type str')
             return None
         # If key not present in contents of json field cannot remove key, return contents
         if current.get(key, None) is None:
             _logger.warning(
-                f"{key}: Key not found in endpoint {endpoint} field {field_name}"
+                f'{key}: Key not found in endpoint {endpoint} field {field_name}'
             )
             return current
         _logger.info(f"Removing key from dict: '{key}'")
@@ -1180,7 +1180,7 @@ class AlyxClient:
             self, endpoint: str = None, uuid: str = None, field_name: str = None
     ) -> None:
         self._check_inputs(endpoint)
-        _ = self.rest(endpoint, "partial_update", id=uuid, data={field_name: None})
+        _ = self.rest(endpoint, 'partial_update', id=uuid, data={field_name: None})
         return _[field_name]
 
     def clear_rest_cache(self):


### PR DESCRIPTION
# Changelog
## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.2]

### Modified

- HOTFIX: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name 