### PR TITLE
V1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - setup method added to ONE function, allowing setup without instantiation
 - version attribute added to ONE function
+- an OneAlyx.eid2pid method
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.2]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.20.0]
+
+### Added
+
+- setup method added to ONE function, allowing setup without instantiation
+- version attribute added to ONE function
 
 ### Modified
 
-- HOTFIX: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name 
+- private tables_dir attribute allows one to separate cache tables location from data location
+- when proving a tag to OneAlyx.load_cache, the default location will be <cache_dir>/<tag>
+- bugfix: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name
+- warns user if downloading cache tables from a different database to the current cache tables
+- possible to set the cache_dir attribute in AlyxClient
 
 ## [1.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - possible to set the cache_dir attribute in AlyxClient
 - function to print REST schemas in AlyxClient
 - batched REST queries in OneAlyx._download_aws to avoid 414 HTTP status code
+- bugfix: solved infinite loop when sliceing paginated response
+- improved performance of remote search
+- lazy fetch of session details in OneAlyx.search 
 
 ## [1.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - warns user if downloading cache tables from a different database to the current cache tables
 - possible to set the cache_dir attribute in AlyxClient
 - function to print REST schemas in AlyxClient
+- batched REST queries in OneAlyx._download_aws to avoid 414 HTTP status code
 
 ## [1.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - bugfix: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name
 - warns user if downloading cache tables from a different database to the current cache tables
 - possible to set the cache_dir attribute in AlyxClient
+- function to print REST schemas in AlyxClient
 
 ## [1.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.1]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.19.2]
+
+### Modified
+
+- HOTFIX: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name 
+
+## [1.19.1]
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - bugfix: solved infinite loop when sliceing paginated response
 - improved performance of remote search
 - lazy fetch of session details in OneAlyx.search
+- one.params.setup allows cache_dir as input
 
 ## [1.19.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - setup method added to ONE function, allowing setup without instantiation
 - version attribute added to ONE function
 - an OneAlyx.eid2pid method
+- one.alf.spec.readableALF converts an ALF object name to a whitespace separated string
 
 ### Modified
 
@@ -18,7 +19,7 @@
 - batched REST queries in OneAlyx._download_aws to avoid 414 HTTP status code
 - bugfix: solved infinite loop when sliceing paginated response
 - improved performance of remote search
-- lazy fetch of session details in OneAlyx.search 
+- lazy fetch of session details in OneAlyx.search
 
 ## [1.19.1]
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,22 +46,14 @@ A problem can arise if something on the Alyx database changes in between the sam
 Usually you can re-run your setup with the following command:
 ```python
 from one.api import ONE
-new_one = ONE().setup(base_url='https://alyx.example.com')
-```
-
-Sometimes if the settings are wrong, the call to `ONE()' raises an error before the setup method is
-called.  To avoid this, run the following command instead:
-
-```python
-from one.api import OneAlyx
-new_one = OneAlyx.setup(base_url='https://alyx.example.com')
+ONE.setup(base_url='https://alyx.example.com')
 ```
 
 ## How do I change my download (a.k.a. cache) directory?
 To **permanently** change the directory, simply re-run the setup routine:
 ```python
 from one.api import ONE
-new_one = ONE().setup()  # Re-run setup for default database
+ONE.setup()  # Re-run setup for default database (takes effect next time you instantiate ONE)
 ```
 When prompted ('Enter the location of the download cache') enter the absolute path of the new download location.
 
@@ -72,6 +64,20 @@ from one.api import ONE
 
 one = ONE(base_url='https://alyx.example.com', cache_dir=Path.home() / 'new_download_dir')
 ```
+**NB**: This will (down)load the cache tables in the newly specified location.  To avoid this, specify the cache table location separately using the `tables_dir` kwarg.
+
+## How do I load cache tables from a different location?
+By default, the cache tables are in the cache_dir root.  You can load cache tables in a different location in the following two ways:
+```python
+from pathlib import Path
+from one.api import ONE
+
+# 1. Specify location upon instantiation
+one = ONE(tables_dir=Path.home() / 'tables_dir')
+# 2. Specify location after instantiation
+one.load_cache(Path.home() / 'tables_dir')
+```
+**NB**: Avoid using the same location for different database cache tables: by default ONE will automatically overwrite tables when a newer version is available. To avoid automatic downloading, set `mode='local'`.
 
 ## How do check who I'm logged in as?
 ```python
@@ -112,18 +118,14 @@ site you are attempting to access with ONE (no need to log in)
 This is a unique issue with the way that the Windows OS handles certificates.
 
 ## How do I download the datasets cache for a specific IBL paper release?
-With OpenAlyx you have the ability to download cache tables containing datasets with a specific release tag. 
+With OpenAlyx you have the ability to download cache tables containing datasets with a specific release tag.
+
 ```python
 from one.api import ONE
+
 one = ONE(base_url='https://openalyx.internationalbrainlab.org', password='international', silent=True)
 TAG = '2021_Q1_IBL_et_al_Behaviour'  # Release tag to download cache for
-
-# Optionally provide a new location for downloading the cache tables so as not to overwrite the main tables
-cache_path = one.cache_dir.joinpath(TAG)
-cache_path.mkdir(exist_ok=True)
-
-# NB: The cache_dir arg only relates to the cache table location NOT the dataset download location
-one.load_cache(tag=TAG, cache_dir=cache_path)
+one.load_cache(tag=TAG)
 ```
 
 ## How do I check which version of ONE I'm using within Python?

--- a/docs/make_script.py
+++ b/docs/make_script.py
@@ -31,17 +31,17 @@ def make_documentation(execute, force, documentation, clean, specific):
         for nb_path_ext in nb_path_external:
             status += process_notebooks(nb_path_ext, execute=True, force=force,
                                         link=True, filename_pattern='docs')
-        _logger.info("Finished processing notebooks")
+        _logger.info('Finished processing notebooks')
 
         if status != 0:
             # One or more examples returned an error
             sys.exit(1)
         else:
             # If no errors make the documentation
-            _logger.info("Cleaning up previous documentation")
-            os.system("make clean")
-            _logger.info("Making documentation")
-            os.system("make html")
+            _logger.info('Cleaning up previous documentation')
+            os.system('make clean')
+            _logger.info('Making documentation')
+            os.system('make html')
             sys.exit(0)
 
     # Case where we only want to build specific examples
@@ -51,7 +51,7 @@ def make_documentation(execute, force, documentation, clean, specific):
                 status += process_notebooks(nb, execute=True, force=force)
             else:
                 status += process_notebooks(nb, execute=True, force=force, link=True)
-            _logger.info("Finished processing notebooks")
+            _logger.info('Finished processing notebooks')
 
         # Create the link files for the other notebooks in external paths that we haven't
         # executed. N.B this must be run after the above commands
@@ -63,25 +63,25 @@ def make_documentation(execute, force, documentation, clean, specific):
             sys.exit(1)
         else:
             # If no errors make the documentation
-            _logger.info("Cleaning up previous documentation")
-            os.system("make clean")
-            _logger.info("Making documentation")
-            os.system("make html")
+            _logger.info('Cleaning up previous documentation')
+            os.system('make clean')
+            _logger.info('Making documentation')
+            os.system('make html')
             sys.exit(0)
 
     if documentation:
         for nb_path_ext in nb_path_external:
             process_notebooks(nb_path_ext, execute=False, link=True, filename_pattern='docs')
 
-        _logger.info("Cleaning up previous documentation")
-        os.system("make clean")
-        _logger.info("Making documentation")
-        os.system("make html")
+        _logger.info('Cleaning up previous documentation')
+        os.system('make clean')
+        _logger.info('Making documentation')
+        os.system('make html')
         sys.exit(0)
 
     # Clean up notebooks in directory if also specified
     if clean:
-        _logger.info("Cleaning up notebooks")
+        _logger.info('Cleaning up notebooks')
         process_notebooks(nb_path, execute=False, cleanup=True)
         for nb_path_ext in nb_path_external:
             process_notebooks(nb_path_ext, execute=False, cleanup=True,
@@ -105,7 +105,7 @@ def make_documentation(execute, force, documentation, clean, specific):
                           ' delete manually')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Make IBL documentation')
 
     parser.add_argument('-e', '--execute', default=False, action='store_true',

--- a/docs/notebooks/recording_data_access.ipynb
+++ b/docs/notebooks/recording_data_access.ipynb
@@ -43,7 +43,7 @@
     "<div class=\"alert alert-info\">\n",
     "Note.\n",
     "\n",
-    "Within a Python session, calling ONE again with the same arguments (from any location) will return \n",
+    "Within a Python session, calling ONE again with the same arguments (from any location) will return\n",
     "the previous object, therefore if you want to stop recording dataset UUIDs you must explicitly set\n",
     "`record_loaded` to False, e.g. `ONE().record_loaded = False`.\n",
     "</div>\n",
@@ -89,7 +89,7 @@
    "source": [
     "import pandas as pd\n",
     "from one.api import ONE\n",
-    "one = ONE(base_url='https://openalyx.internationalbrainlab.org', silent=True)\n",
+    "one = ONE(base_url='https://openalyx.internationalbrainlab.org')\n",
     "\n",
     "# Turn on recording of loaded dataset UUIDs\n",
     "one.record_loaded = True\n",

--- a/docs/one_installation.md
+++ b/docs/one_installation.md
@@ -19,7 +19,8 @@ use a local file system
 By default ONE is configured to connect to the public IBL database, this can be setup by typing the following
 ```python
 from one.api import ONE
-one = ONE(silent=True)
+ONE.setup(silent=True)  # silent means use default parameters for the IBL public database
+one = ONE()
 ```
 
 If you are having an issue at this stage, or need to re-configure ONE, please see [this FAQ page](/FAQ.md#i-made-a-mistake-during-setup-and-now-can-t-call-setup-how-do-i-fix-it).
@@ -59,7 +60,7 @@ one = ONE()
 
 To change your default database, or re-run the setup for a given database, you can use the following
 ```python
-one = ONE().setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
+ONE.setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
 ```
 
 ## 4. Update

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.19.1'
+__version__ = '1.19.2'

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.19.2'
+__version__ = '1.20.0'

--- a/one/alf/spec.py
+++ b/one/alf/spec.py
@@ -1,4 +1,4 @@
-"""The complete ALF specification descriptors and validators"""
+"""The complete ALF specification descriptors and validators."""
 import re
 import textwrap
 from uuid import UUID
@@ -193,6 +193,10 @@ def _dromedary(string) -> str:
     >>> _dromedary('motion_energy') == 'motionEnergy'
     >>> _dromedary('passive_RFM') == 'passive RFM'
     >>> _dromedary('FooBarBaz') == 'fooBarBaz'
+
+    See Also
+    --------
+    readableALF
     """
     def _capitalize(x):
         return x if x.isupper() else x.capitalize()
@@ -390,3 +394,42 @@ def to_alf(object, attribute, extension, namespace=None, timescale=None, extra=N
              *extra,
              extension)
     return '.'.join(parts)
+
+
+def readableALF(name: str, capitalize: bool = False) -> str:
+    """Convert camel case string to space separated string.
+
+    Given an ALF object name or attribute, return a string where the camel case words are space
+    separated.  Acronyms/initialisms are preserved.
+
+    Parameters
+    ----------
+    name : str
+        The ALF part to format (e.g. object name or attribute).
+    capitalize : bool
+        If true, return with the first letter capitalized.
+
+    Returns
+    -------
+    str
+        The name formatted for display, with spaces and capitalization.
+
+    Examples
+    --------
+    >>> readableALF('sparseNoise') == 'sparse noise'
+    >>> readableALF('someROIDataset') == 'some ROI dataset'
+    >>> readableALF('someROIDataset', capitalize=True) == 'Some ROI dataset'
+
+    See Also
+    --------
+    _dromedary
+    """
+    words = []
+    i = 0
+    matches = re.finditer(r'[A-Z](?=[a-z0-9])|(?<=[a-z0-9])[A-Z]', name)
+    for j in map(re.Match.start, matches):
+        words.append(name[i:j])
+        i = j
+    words.append(name[i:])
+    display_str = ' '.join(map(lambda s: s if s.isupper() else s.lower(), words))
+    return display_str[0].upper() + display_str[1:] if capitalize else display_str

--- a/one/api.py
+++ b/one/api.py
@@ -1674,7 +1674,7 @@ class OneAlyx(One):
             if field == 'date_range':
                 params[field] = [x.date().isoformat() for x in util.validate_date_range(value)]
             elif field == 'dataset':
-                query = ('data_dataset_session_related__dataset_type__name__icontains,' +
+                query = ('data_dataset_session_related__name__icontains,' +
                          ','.join(util.ensure_list(value)))
                 params['django'] += (',' if params['django'] else '') + query
             elif field == 'laboratory':

--- a/one/api.py
+++ b/one/api.py
@@ -27,11 +27,12 @@ import one.alf.exceptions as alferr
 from .alf.cache import make_parquet_db
 from .alf.files import rel_path_parts, get_session_path, get_alf_path, add_uuid_string
 from .alf.spec import is_uuid_string
+from . import __version__
 from one.converters import ConversionMixin
 import one.util as util
 
 _logger = logging.getLogger(__name__)
-
+__all__ = ['ONE', 'One', 'OneAlyx']
 """int: The number of download threads"""
 N_THREADS = 4
 
@@ -42,7 +43,7 @@ class One(ConversionMixin):
         'dataset', 'date_range', 'laboratory', 'number', 'projects', 'subject', 'task_protocol'
     )
 
-    def __init__(self, cache_dir=None, mode='auto', wildcards=True):
+    def __init__(self, cache_dir=None, mode='auto', wildcards=True, tables_dir=None):
         """An API for searching and loading data on a local filesystem
 
         Parameters
@@ -55,11 +56,17 @@ class One(ConversionMixin):
             Query mode, options include 'auto' (reload cache daily), 'local' (offline) and
             'refresh' (always reload cache tables).  Most methods have a `query_type` parameter
             that can override the class mode.
+        wildcards : bool
+            If true, use unix shell style matching instead of regular expressions.
+        tables_dir : str, pathlib.Path
+            An optional location of the cache tables.  If None, the tables are assumed to be in the
+            cache_dir.
         """
         # get parameters override if inputs provided
         super().__init__()
         if not getattr(self, 'cache_dir', None):  # May already be set by subclass
             self.cache_dir = cache_dir or one.params.get_cache_dir()
+        self._tables_dir = tables_dir or self.cache_dir
         self.cache_expiry = timedelta(hours=24)
         self.mode = mode
         self.wildcards = wildcards  # Flag indicating whether to use regex or wildcards
@@ -92,19 +99,20 @@ class One(ConversionMixin):
             'raw': {}  # map of original table metadata
         }})
 
-    def load_cache(self, cache_dir=None, **kwargs):
+    def load_cache(self, tables_dir=None, **kwargs):
         """
         Load parquet cache files from a local directory.
 
         Parameters
         ----------
-        cache_dir : str, pathlib.Path
-            An optional directory location of the parquet files, defaults to One.cache_dir.
+        tables_dir : str, pathlib.Path
+            An optional directory location of the parquet files, defaults to One._tables_dir.
         """
         self._reset_cache()
         meta = self._cache['_meta']
         INDEX_KEY = '.?id'
-        for cache_file in Path(cache_dir or self.cache_dir).glob('*.pqt'):
+        self._tables_dir = Path(tables_dir or self._tables_dir or self.cache_dir)
+        for cache_file in self._tables_dir.glob('*.pqt'):
             table = cache_file.stem
             # we need to keep this part fast enough for transient objects
             cache, meta['raw'][table] = parquet.load(cache_file)
@@ -326,7 +334,7 @@ class One(ConversionMixin):
                 ids = parquet.np2str(ids)
 
         timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S%z")
-        filename = Path(self.cache_dir) / f'{timestamp}_loaded_{name}s.csv'
+        filename = Path(self._tables_dir or self.cache_dir) / f'{timestamp}_loaded_{name}s.csv'
         pd.DataFrame(ids, columns=[name]).to_csv(filename, index=False)
         if clear_list:
             self._cache['_loaded_datasets'] = np.array([])
@@ -1285,17 +1293,17 @@ class One(ConversionMixin):
         Parameters
         ----------
         cache_dir : pathlib.Path, str
-            A path to the ALF data directory
+            A path to the ALF data directory.
         silent : (False) bool
-            when True will prompt for cache_dir if cache_dir is None, and overwrite cache if any
-            when False will use cwd for cache_dir if cache_dir is None and use existing cache
+            When True will prompt for cache_dir, if cache_dir is None, and overwrite cache if any.
+            When False will use cwd for cache_dir, if cache_dir is None, and use existing cache.
         **kwargs
             Optional arguments to pass to one.alf.cache.make_parquet_db.
 
         Returns
         -------
         One
-            An instance of One for the provided cache directory
+            An instance of One for the provided cache directory.
         """
         if not cache_dir:
             if not silent:
@@ -1329,12 +1337,15 @@ def ONE(*, mode='auto', wildcards=True, **kwargs):
         Query mode, options include 'auto', 'local' (offline) and 'remote' (online only).  Most
         methods have a `query_type` parameter that can override the class mode.
     wildcards : bool
-        If true all mathods use unix shell style pattern matching, otherwise regular expressions
+        If true all methods use unix shell style pattern matching, otherwise regular expressions
         are used.
-    cache_dir : str, Path
+    cache_dir : str, pathlib.Path
         Path to the data files.  If Alyx parameters have been set up for this location,
         an OneAlyx instance is returned.  If data_dir and base_url are None, the default
         location is used.
+    tables_dir : str, pathlib.Path
+        An optional location of the cache tables.  If None, the tables are assumed to be in the
+        cache_dir.
     base_url : str
         An Alyx database URL.  The URL must start with 'http'.
     username : str
@@ -1372,7 +1383,7 @@ def ONE(*, mode='auto', wildcards=True, **kwargs):
 class OneAlyx(One):
     """An API for searching and loading data through the Alyx database"""
     def __init__(self, username=None, password=None, base_url=None, cache_dir=None,
-                 mode='auto', wildcards=True, **kwargs):
+                 mode='auto', wildcards=True, tables_dir=None, **kwargs):
         """An API for searching and loading data through the Alyx database
 
         Parameters
@@ -1383,10 +1394,13 @@ class OneAlyx(One):
         wildcards : bool
             If true, methods allow unix shell style pattern matching, otherwise regular
             expressions are supported
-        cache_dir : str, Path
+        cache_dir : str, pathlib.Path
             Path to the data files.  If Alyx parameters have been set up for this location,
             an OneAlyx instance is returned.  If data_dir and base_url are None, the default
             location is used.
+        tables_dir : str, pathlib.Path
+            An optional location of the cache tables.  If None, the tables are assumed to be in the
+            cache_dir.
         base_url : str
             An Alyx database URL.  The URL must start with 'http'.
         username : str
@@ -1406,12 +1420,13 @@ class OneAlyx(One):
                                          **kwargs)
         self._search_endpoint = 'sessions'
         # get parameters override if inputs provided
-        super(OneAlyx, self).__init__(mode=mode, wildcards=wildcards, cache_dir=cache_dir)
+        super(OneAlyx, self).__init__(
+            mode=mode, wildcards=wildcards, tables_dir=tables_dir, cache_dir=cache_dir)
 
     def __repr__(self):
         return f'One ({"off" if self.offline else "on"}line, {self.alyx.base_url})'
 
-    def load_cache(self, cache_dir=None, clobber=False, tag=None):
+    def load_cache(self, tables_dir=None, clobber=False, tag=None):
         """
         Load parquet cache files.  If the local cache is sufficiently old, this method will query
         the database for the location and creation date of the remote cache.  If newer, it will be
@@ -1421,22 +1436,26 @@ class OneAlyx(One):
 
         Parameters
         ----------
-        cache_dir : str, pathlib.Path
-            An optional directory location of the parquet files, defaults to One.cache_dir.
+        tables_dir : str, pathlib.Path
+            An optional directory location of the parquet files, defaults to One._tables_dir.
         clobber : bool
             If True, query Alyx for a newer cache even if current (local) cache is recent.
         tag : str
             An optional Alyx dataset tag for loading cache tables containing a subset of datasets.
         """
         cache_meta = self._cache.get('_meta', {})
-        cache_dir = cache_dir or self.cache_dir
+        raw_meta = cache_meta.get('raw', {}).values() or [{}]
         # If user provides tag that doesn't match current cache's tag, always download.
         # NB: In the future 'database_tags' may become a list.
-        current_tags = [x.get('database_tags') for x in cache_meta.get('raw', {}).values() or [{}]]
+        current_tags = [x.get('database_tags') for x in raw_meta]
+        if len(set(filter(None, current_tags))) > 1:
+            raise NotImplementedError(
+                'Loading cache tables with multiple tags is not currently supported'
+            )
         tag = tag or current_tags[0]  # For refreshes take the current tag as default
         different_tag = any(x != tag for x in current_tags)
-        if not clobber or different_tag:
-            super(OneAlyx, self).load_cache(cache_dir)  # Load any present cache
+        if not (clobber or different_tag):
+            super(OneAlyx, self).load_cache(tables_dir)  # Load any present cache
             cache_meta = self._cache.get('_meta', {})  # TODO Make walrus when we drop 3.7 support
             expired = self._cache and cache_meta['expired']
             if not expired or self.mode in {'local', 'remote'}:
@@ -1468,15 +1487,34 @@ class OneAlyx(One):
             # Check whether remote cache more recent
             remote_created = datetime.fromisoformat(cache_info['date_created'])
             local_created = cache_meta.get('created_time', None)
-            if local_created and (remote_created - local_created) < timedelta(minutes=1):
+            fresh = local_created and (remote_created - local_created) < timedelta(minutes=1)
+            if fresh and not different_tag:
                 _logger.info('No newer cache available')
                 return
 
+            # Set the cache table directory location
+            if tables_dir:  # If tables directory specified, use that
+                self._tables_dir = Path(tables_dir)
+            elif different_tag:  # Otherwise use a subdirectory for a given tag
+                self._tables_dir = self.cache_dir / tag
+                self._tables_dir.mkdir(exist_ok=True)
+            else:  # Otherwise use the previous location (default is the data cache directory)
+                self._tables_dir = self._tables_dir or self.cache_dir
+
+            # Check if the origin has changed. This is to warn users if downloading from a
+            # different database to the one currently loaded.
+            prev_origin = list(set(filter(None, (x.get('origin') for x in raw_meta))))
+            origin = cache_info.get('origin', 'unknown')
+            if prev_origin and origin not in prev_origin:
+                warnings.warn(
+                    'Downloading cache tables from another origin '
+                    f'("{origin}" instead of "{", ".join(prev_origin)}")')
+
             # Download the remote cache files
             _logger.info('Downloading remote caches...')
-            files = self.alyx.download_cache_tables(cache_info.get('location'), cache_dir)
+            files = self.alyx.download_cache_tables(cache_info.get('location'), self._tables_dir)
             assert any(files)
-            super(OneAlyx, self).load_cache(cache_dir)  # Reload cache after download
+            super(OneAlyx, self).load_cache(self._tables_dir)  # Reload cache after download
         except (requests.exceptions.HTTPError, wc.HTTPError, requests.exceptions.SSLError) as ex:
             _logger.debug(ex)
             _logger.error(f'{type(ex).__name__}: Failed to load the remote cache file')
@@ -2234,3 +2272,29 @@ class OneAlyx(One):
         out.update({'local_path': self.eid2path(eid),
                     'date': datetime.fromisoformat(out['start_time']).date()})
         return out
+
+
+def _setup(**kwargs):
+    """A setup method for the main ONE function.
+
+    Clears the ONE LRU cache before running setup, which ensures ONE is re-instantiated after
+    modifying parameter defaults.  NB: This docstring is overwritten by the one.params.setup
+    docstring upon module init.
+
+    Parameters
+    ----------
+    **kwargs
+        See one.params.setup.
+
+    Returns
+    -------
+    IBLParams
+        An updated cache map.
+    """
+    ONE.cache_clear()
+    return one.params.setup(**kwargs)
+
+
+ONE.setup = _setup
+ONE.setup.__doc__ = one.params.setup.__doc__
+ONE.version = __version__

--- a/one/api.py
+++ b/one/api.py
@@ -2059,6 +2059,10 @@ class OneAlyx(One):
         -------
         OneAlyx
             An instance of OneAlyx for the newly set up database URL
+
+        See Also
+        --------
+        one.params.setup
         """
         base_url = base_url or one.params.get_default_client()
         cache_map = one.params.setup(client=base_url, **kwargs)

--- a/one/tests/alf/test_alf_spec.py
+++ b/one/tests/alf/test_alf_spec.py
@@ -121,12 +121,21 @@ class TestALFSpec(unittest.TestCase):
         self.assertCountEqual(verifiable, expected)
 
     def test_dromedary(self):
-        """Test for one.alf.spec._dromedary"""
+        """Test for one.alf.spec._dromedary function."""
         self.assertEqual(alf_spec._dromedary('Hello world'), 'helloWorld')
         self.assertEqual(alf_spec._dromedary('motion_energy'), 'motionEnergy')
         self.assertEqual(alf_spec._dromedary('FooBarBaz'), 'fooBarBaz')
         self.assertEqual(alf_spec._dromedary('passive_RFM'), 'passiveRFM')
         self.assertEqual(alf_spec._dromedary('ROI Motion Energy'), 'ROIMotionEnergy')
+
+    def test_readable_ALF(self):
+        """Test for one.alf.spec.readableALF function."""
+        self.assertEqual(alf_spec.readableALF('DAQData'), 'DAQ data')
+        self.assertEqual(alf_spec.readableALF('ROIMotion'), 'ROI motion')
+        self.assertEqual(alf_spec.readableALF('blueChipTime'), 'blue chip time')
+        self.assertEqual(alf_spec.readableALF('someROIDataset'), 'some ROI dataset')
+        self.assertEqual(alf_spec.readableALF('fooBAR'), 'foo BAR')
+        self.assertEqual(alf_spec.readableALF('fooBAR', capitalize=True), 'Foo BAR')
 
     def test_is_session_folder(self):
         """Test for one.alf.spec.is_session_folder"""

--- a/one/tests/test_alyxclient.py
+++ b/one/tests/test_alyxclient.py
@@ -452,6 +452,16 @@ class TestMisc(unittest.TestCase):
             self.assertIsNone(ac.cache_mode)
         self.assertIsNotNone(ac.cache_mode)
 
+    def test_cache_dir_setter(self):
+        """Tests setter for AlyxClient.cache_dir attribute."""
+        prev_path = ac.cache_dir
+        try:
+            ac.cache_dir = prev_path / 'foobar'
+            self.assertEqual(ac.cache_dir, ac._par.CACHE_DIR)
+            self.assertTrue(str(ac.cache_dir).endswith('foobar'))
+        finally:
+            ac._par = ac._par.set('CACHE_DIR', prev_path)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False, verbosity=2)

--- a/one/tests/test_alyxrest.py
+++ b/one/tests/test_alyxrest.py
@@ -180,7 +180,15 @@ class TestREST(unittest.TestCase):
         with unittest.mock.patch('sys.stdout', new_callable=io.StringIO) as stdout:
             info = self.alyx.print_endpoint_info(endpoint)
             self.assertEqual(self.alyx.rest_schemes[endpoint], info)
+            self.assertIsNot(self.alyx.rest_schemes[endpoint], info)  # Ensure copy returned
             self.assertTrue(stdout.getvalue().strip(), 'failed to print endpoint info')
+        # Check action input
+        with unittest.mock.patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            info = self.alyx.print_endpoint_info(endpoint, 'create')
+            self.assertEqual(self.alyx.rest_schemes[endpoint]['create'], info)
+            self.assertIsNot(self.alyx.rest_schemes[endpoint]['create'], info)  # Ensure copy
+            self.assertTrue(stdout.getvalue().strip(), 'failed to print endpoint info')
+            self.assertEqual("'create'\n\t", stdout.getvalue().strip()[:10])
 
     """Specific Alyx REST endpoint tests"""
     def test_water_restriction(self):

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -232,6 +232,7 @@ class TestOnlineConverters(unittest.TestCase):
         # Create ONE object with temp cache dir
         cls.one = ONE(**TEST_DB_2)
         cls.eid = '4ecb5d24-f5cc-402c-be28-9d0f7cb14b3a'
+        cls.pid = 'da8dfec1-d265-44e8-84ce-6ae9c109b8bd'
         cls.session_record = cls.one.get_details(cls.eid)
 
     def test_to_eid(self):
@@ -291,7 +292,7 @@ class TestOnlineConverters(unittest.TestCase):
         self.assertTrue(len(verifiable) == 2)
 
     def test_path2eid(self):
-        """Test for OneAlyx.path2eid"""
+        """Test for OneAlyx.path2eid method."""
         test_path = Path(self.one.cache_dir).joinpath('hoferlab', 'Subjects', 'SWC_043',
                                                       '2020-09-21', '001',)
         verifiable = self.one.path2eid(test_path, query_type='remote')
@@ -299,6 +300,26 @@ class TestOnlineConverters(unittest.TestCase):
         # Check works with list
         verifiable = self.one.path2eid([test_path, test_path], query_type='remote')
         self.assertEqual([self.eid, self.eid], verifiable)
+
+    def test_pid2eid(self):
+        """Test for OneAlyx.pid2eid method."""
+        self.assertRaises(NotImplementedError, self.one.pid2eid, self.pid, query_type='local')
+        self.assertEqual((self.eid, 'probe00'), self.one.pid2eid(self.pid))
+
+    def test_eid2pid(self):
+        """Test for OneAlyx.eid2pid method."""
+        self.assertRaises(NotImplementedError, self.one.eid2pid, self.eid, query_type='local')
+        # Check invalid eid
+        self.assertEqual((None, None), self.one.eid2pid(None))
+        self.assertEqual((None, None, None), self.one.eid2pid(None, details=True))
+        # Check valid eid
+        expected = ([self.pid, '6638cfb3-3831-4fc2-9327-194b76cf22e1'], ['probe00', 'probe01'])
+        self.assertEqual(expected, self.one.eid2pid(self.eid))
+        *_, det = self.one.eid2pid(self.eid, details=True)
+        self.assertEqual(2, len(det))
+        expected_keys = {'id', 'name', 'model', 'serial'}
+        for d in det:
+            self.assertTrue(set(d.keys()) >= expected_keys)
 
 
 class TestAlyx2Path(unittest.TestCase):

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1193,9 +1193,11 @@ class TestOneRemote(unittest.TestCase):
         eids = self.one.search(subject='SWC_043', date='2020-09-21', query_type='remote')
         self.assertCountEqual(eids, [self.eid])
 
-        eids = self.one.search(date=[datetime.date(2020, 9, 21), datetime.date(2020, 9, 22)],
-                               lab='hoferlab', query_type='remote')
-        self.assertCountEqual(eids, [self.eid])
+        date_range = [datetime.date(2020, 9, 21), datetime.date(2020, 9, 22)]
+        eids = self.one.search(date=date_range, lab='hoferlab', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+        dates = set(map(lambda x: self.one.get_details(x)['date'], eids))
+        self.assertTrue(dates <= set(date_range))
 
         # Test limit arg and LazyId
         eids = self.one.search(date='2020-03-23', limit=2, query_type='remote')
@@ -1207,6 +1209,17 @@ class TestOneRemote(unittest.TestCase):
         self.assertIn(self.eid, list(eids))
 
         eids = self.one.search(lab='hoferlab', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+
+        # Test dataset and dataset_types kwargs
+        eids = self.one.search(dataset='trials.table.pqt', query_type='remote')
+        self.assertIn(self.eid, list(eids))
+        eids = self.one.search(dataset='trials.intervals.npy', query_type='remote')
+        self.assertNotIn(self.eid, list(eids))
+
+        eids = self.one.search(dataset_type='trials.table.pqt', query_type='remote')
+        self.assertEqual(0, len(eids))
+        eids = self.one.search(dataset_type='trials.table', date='2020-09-21', query_type='remote')
         self.assertIn(self.eid, list(eids))
 
     def test_load_dataset(self):

--- a/one/tests/test_one.py
+++ b/one/tests/test_one.py
@@ -1205,7 +1205,7 @@ class TestOneRemote(unittest.TestCase):
             self.one.list_datasets(query_type='remote')
 
     def test_search(self):
-        """Test OneAlyx.search"""
+        """Test OneAlyx.search method in remote mode."""
         eids = self.one.search(subject='SWC_043', query_type='remote')
         self.assertIn(self.eid, list(eids))
 

--- a/one/tests/test_params.py
+++ b/one/tests/test_params.py
@@ -65,6 +65,19 @@ class TestParamSetup(unittest.TestCase):
         with self.assertRaises(ValueError), mock.patch('one.params.input', new=self._mock_input):
             one.params.setup()
 
+        # Check uses cache_dir arg in cache map
+        location = str(Path(self.par_dir.name) / 'data')
+        # Check with user prompts
+        self.url = ''  # User selects default
+        with mock.patch('one.params.input', new=self._mock_input):
+            cache = one.params.setup(cache_dir=location)
+            self.assertIn(location, cache.CLIENT_MAP.values())
+
+        # Check warns when cache_dir conflicts in silent mode
+        with self.assertWarns(UserWarning):
+            cache = one.params.setup(TEST_DB_1['base_url'][8:], cache_dir=location, silent=True)
+        self.assertEqual(location, cache.CLIENT_MAP[cache.DEFAULT])
+
 
 class TestONEParamUtil(unittest.TestCase):
     """Test class for one.params utility functions"""
@@ -114,5 +127,5 @@ class TestONEParamUtil(unittest.TestCase):
         self.assertTrue(cache_dir.exists())
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(exit=False, verbosity=2)

--- a/one/util.py
+++ b/one/util.py
@@ -302,7 +302,7 @@ def filter_datasets(all_datasets, filename=None, collection=None, revision=None,
     Parameters
     ----------
     all_datasets : pandas.DataFrame
-        A datasets cache table
+        A datasets cache table.
     filename : str, dict, None
         A filename str or a dict of alf parts.  Regular expressions permitted.
     collection : str, None
@@ -315,14 +315,14 @@ def filter_datasets(all_datasets, filename=None, collection=None, revision=None,
         instead.  When false the revision string is matched like collection and filename,
         with regular expressions permitted.
     assert_unique : bool
-        When true an error is raised if multiple collections or datasets are found
+        When true an error is raised if multiple collections or datasets are found.
     wildcards : bool
-        If true, use unix shell style matching instead of regular expressions
+        If true, use unix shell style matching instead of regular expressions.
 
     Returns
     -------
     pd.DataFrame
-        A slice of all_datasets that match the filters
+        A slice of all_datasets that match the filters.
 
     Examples
     --------

--- a/one/util.py
+++ b/one/util.py
@@ -342,6 +342,12 @@ def filter_datasets(all_datasets, filename=None, collection=None, revision=None,
     Filter by filename parts
 
     >>> datasets = filter_datasets(all_datasets, dict(object='spikes', attribute='times'))
+
+    Notes
+    -----
+    - It is not possible to match datasets that are in a given collection OR NOT in ANY collection.
+     e.g. filter_datasets(dsets, collection=['alf', '']) will not match the latter. For this you
+     must use two separate queries.
     """
     # Create a regular expression string to match relative path against
     filename = filename or {}

--- a/one/util.py
+++ b/one/util.py
@@ -510,31 +510,32 @@ class LazyId(Mapping):
     """
     Using a paginated response object or list of session records, extracts eid string when required
     """
-    def __init__(self, pg):
+    def __init__(self, pg, func=None):
         self._pg = pg
+        self.func = func or self.ses2eid
 
     def __getitem__(self, item):
-        return self.ses2eid(self._pg.__getitem__(item))
+        return self.func(self._pg.__getitem__(item))
 
     def __len__(self):
         return self._pg.__len__()
 
     def __iter__(self):
-        return map(self.ses2eid, self._pg.__iter__())
+        return map(self.func, self._pg.__iter__())
 
     @staticmethod
     def ses2eid(ses):
-        """
+        """Given one or more session dictionaries, extract and return the session UUID.
 
         Parameters
         ----------
         ses : one.webclient._PaginatedResponse, dict, list
-            A collection of Alyx REST sessions endpoint records
+            A collection of Alyx REST sessions endpoint records.
 
         Returns
         -------
         str, list
-            One or more experiment ID strings
+            One or more experiment ID strings.
         """
         if isinstance(ses, list):
             return [LazyId.ses2eid(x) for x in ses]

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -214,7 +214,7 @@ class _PaginatedResponse(Mapping):
     def __getitem__(self, item):
         if isinstance(item, slice):
             while None in self._cache[item]:
-                self.populate(self._cache[item].index(None))
+                self.populate(item.start + self._cache[item].index(None))
         elif self._cache[item] is None:
             self.populate(item)
         return self._cache[item]

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -526,6 +526,12 @@ class AlyxClient:
         """pathlib.Path: The location of the downloaded file cache"""
         return Path(self._par.CACHE_DIR)
 
+    @cache_dir.setter
+    def cache_dir(self, cache_dir):
+        cache_dir = Path(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        self._par = self._par.set('CACHE_DIR', cache_dir)
+
     @property
     def is_logged_in(self):
         """bool: Check if user logged into Alyx database; True if user is authenticated"""
@@ -533,11 +539,11 @@ class AlyxClient:
 
     def list_endpoints(self):
         """
-        Return a list of available REST endpoints
+        Return a list of available REST endpoints.
 
         Returns
         -------
-            List of REST endpoint strings
+            List of REST endpoint strings.
         """
         EXCLUDE = ('_type', '_meta', '', 'auth-token')
         return sorted(x for x in self.rest_schemes.keys() if x not in EXCLUDE)
@@ -586,7 +592,7 @@ class AlyxClient:
     def authenticate(self, username=None, password=None, cache_token=True, force=False):
         """
         Gets a security token from the Alyx REST API to create requests headers.
-        Credentials are loaded via one.params
+        Credentials are loaded via one.params.
 
         Parameters
         ----------
@@ -595,9 +601,9 @@ class AlyxClient:
         password : str
             Alyx password.  If None, token not cached and not silent, user is prompted.
         cache_token : bool
-            If true, the token is cached for subsequent auto-logins
+            If true, the token is cached for subsequent auto-logins.
         force : bool
-            If true, any cached token is ignored
+            If true, any cached token is ignored.
         """
         # Get username
         if username is None:
@@ -653,11 +659,11 @@ class AlyxClient:
             self._par = self._par.set('TOKEN', tokens)
         self.user = username
         if not self.silent:
-            print(f"Connected to {self.base_url} as {self.user}")
+            print(f'Connected to {self.base_url} as user "{self.user}"')
 
     def logout(self):
-        """Log out from Alyx
-        Deletes the cached authentication token for the currently logged-in user
+        """Log out from Alyx.
+        Deletes the cached authentication token for the currently logged-in user.
         """
         if not self.is_logged_in:
             return

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -1104,17 +1104,17 @@ class AlyxClient:
         Examples
         --------
         >>> client = AlyxClient()
-        >>> client.json_field_update("sessions", "eid_str", "extended_qc", {"key": "value"})
+        >>> client.json_field_update('sessions', 'eid_str', 'extended_qc', {'key': 'value'})
         """
         self._check_inputs(endpoint)
         # Load current json field contents
-        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        current = self.rest(endpoint, 'read', id=uuid)[field_name]
         if current is None:
             current = {}
 
         if not isinstance(current, dict):
             _logger.warning(
-                f"Current json field {field_name} does not contains a dict, aborting update"
+                f'Current json field {field_name} does not contains a dict, aborting update'
             )
             return current
 
@@ -1123,7 +1123,7 @@ class AlyxClient:
         # Prepare data to patch
         patch_dict = {field_name: current}
         # Upload new extended_qc to session
-        ret = self.rest(endpoint, "partial_update", id=uuid, data=patch_dict)
+        ret = self.rest(endpoint, 'partial_update', id=uuid, data=patch_dict)
         return ret[field_name]
 
     def json_field_remove_key(
@@ -1154,18 +1154,18 @@ class AlyxClient:
             New content of json field
         """
         self._check_inputs(endpoint)
-        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        current = self.rest(endpoint, 'read', id=uuid)[field_name]
         # If no contents, cannot remove key, return
         if current is None:
             return current
         # if contents are not dict, cannot remove key, return contents
         if isinstance(current, str):
-            _logger.warning(f"Cannot remove key {key} content of json field is of type str")
+            _logger.warning(f'Cannot remove key {key} content of json field is of type str')
             return None
         # If key not present in contents of json field cannot remove key, return contents
         if current.get(key, None) is None:
             _logger.warning(
-                f"{key}: Key not found in endpoint {endpoint} field {field_name}"
+                f'{key}: Key not found in endpoint {endpoint} field {field_name}'
             )
             return current
         _logger.info(f"Removing key from dict: '{key}'")
@@ -1180,7 +1180,7 @@ class AlyxClient:
             self, endpoint: str = None, uuid: str = None, field_name: str = None
     ) -> None:
         self._check_inputs(endpoint)
-        _ = self.rest(endpoint, "partial_update", id=uuid, data={field_name: None})
+        _ = self.rest(endpoint, 'partial_update', id=uuid, data={field_name: None})
         return _[field_name]
 
     def clear_rest_cache(self):

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -548,30 +548,38 @@ class AlyxClient:
         EXCLUDE = ('_type', '_meta', '', 'auth-token')
         return sorted(x for x in self.rest_schemes.keys() if x not in EXCLUDE)
 
-    def print_endpoint_info(self, endpoint):
+    def print_endpoint_info(self, endpoint, action=None):
         """
-        Print the available actions and query parameteres for a given REST endpoint.
+        Print the available actions and query parameters for a given REST endpoint.
 
         Parameters
         ----------
         endpoint : str
             An Alyx REST endpoint to query.
+        action : str
+            An optional action (e.g. 'list') to print. If None, all actions are printed.
+
+        Returns
+        -------
+        dict, list
+            A dictionary of endpoint query parameter details or a list of parameter details if
+            action is not None.
         """
         rs = self.rest_schemes
         if endpoint not in rs:
             return print(f'Endpoint "{endpoint}" does not exist')
 
-        for action in rs[endpoint]:
+        for _action in (rs[endpoint] if action is None else [action]):
             doc = []
-            pprint(action)
-            for f in rs[endpoint][action]['fields']:
+            pprint(_action)
+            for f in rs[endpoint][_action]['fields']:
                 required = ' (required): ' if f.get('required', False) else ': '
-                doc.append(f"\t\"{f['name']}\"{required}{f['schema']['_type']}"
-                           f", {f['schema']['description']}")
+                doc.append(f'\t"{f["name"]}"{required}{f["schema"]["_type"]}'
+                           f', {f["schema"]["description"]}')
             doc.sort()
             [print(d) for d in doc if '(required)' in d]
             [print(d) for d in doc if '(required)' not in d]
-        return rs[endpoint]
+        return (rs[endpoint] if action is None else rs[endpoint][action]).copy()
 
     @_cache_response
     def _generic_request(self, reqfunction, rest_query, data=None, files=None):


### PR DESCRIPTION
# Changelog
## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.20.0]

### Added

- setup method added to ONE function, allowing setup without instantiation
- version attribute added to ONE function
- an OneAlyx.eid2pid method
- one.alf.spec.readableALF converts an ALF object name to a whitespace separated string

### Modified

- private tables_dir attribute allows one to separate cache tables location from data location
- when proving a tag to OneAlyx.load_cache, the default location will be <cache_dir>/<tag>
- bugfix: OneAlyx.search dataset kwarg in remote mode now matches dataset name instead of dataset type name
- warns user if downloading cache tables from a different database to the current cache tables
- possible to set the cache_dir attribute in AlyxClient
- function to print REST schemas in AlyxClient
- batched REST queries in OneAlyx._download_aws to avoid 414 HTTP status code
- bugfix: solved infinite loop when sliceing paginated response
- improved performance of remote search
- lazy fetch of session details in OneAlyx.search
- one.params.setup allows cache_dir as input
