### PR TITLE
HOTFIX: mkdir called on destination instead of default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.21.3]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.21.4]
 
 ### Modified
 
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.21.3]
+## [1.21.3]
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Modified
 
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+- HOTFIX: fix error in load_cache when switching from tagged cache
+- frozen pandas below 2.0
 
 ## [1.21.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ### Modified
 
+- HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.21.3]
+
+### Modified
+
 - HOTFIX: AWS S3 resource returned unsigned if 'public' in bucket name and no credentials on Alyx 
 
 ## [1.21.2]

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.21.3'
+__version__ = '1.21.4'

--- a/one/api.py
+++ b/one/api.py
@@ -665,25 +665,25 @@ class One(ConversionMixin):
             Experiment session identifier; may be a UUID, URL, experiment reference string
             details dict or Path.
         filename : str, dict, list
-            Filters datasets and returns only the ones matching the filename
+            Filters datasets and returns only the ones matching the filename.
             Supports lists asterisks as wildcards.  May be a dict of ALF parts.
         collection : str, list
             The collection to which the object belongs, e.g. 'alf/probe01'.
             This is the relative path of the file from the session root.
             Supports asterisks as wildcards.
         revision : str
-            Filters datasets and returns only the ones matching the revision
-            Supports asterisks as wildcards
+            Filters datasets and returns only the ones matching the revision.
+            Supports asterisks as wildcards.
         details : bool
             When true, a pandas DataFrame is returned, otherwise a numpy array of
             relative paths (collection/revision/filename) - see one.alf.spec.describe for details.
         query_type : str
-            Query cache ('local') or Alyx database ('remote')
+            Query cache ('local') or Alyx database ('remote').
 
         Returns
         -------
         np.ndarray, pd.DataFrame
-            Slice of datasets table or numpy array if details is False
+            Slice of datasets table or numpy array if details is False.
 
         Examples
         --------
@@ -1447,7 +1447,7 @@ class OneAlyx(One):
         raw_meta = cache_meta.get('raw', {}).values() or [{}]
         # If user provides tag that doesn't match current cache's tag, always download.
         # NB: In the future 'database_tags' may become a list.
-        current_tags = [x.get('database_tags') for x in raw_meta]
+        current_tags = flatten(x.get('database_tags') for x in raw_meta)
         if len(set(filter(None, current_tags))) > 1:
             raise NotImplementedError(
                 'Loading cache tables with multiple tags is not currently supported'
@@ -1737,6 +1737,16 @@ class OneAlyx(One):
         (list of dicts)
             If details is True, also returns a list of dictionaries, each entry corresponding to a
             matching insertion.
+
+        Notes
+        -----
+        - This method does not use the local cache and therefore can not work in 'local' mode.
+
+        Examples
+        --------
+        List the insertions associated with a given data release
+        >>> tag = '2022_Q2_IBL_et_al_RepeatedSite'
+        ... ins = one.search_insertions(django='datasets__tags__name,' + tag)
         """
         query_type = query_type or self.mode
         if query_type == 'local' and 'insertions' not in self._cache.keys():

--- a/one/tests/remote/test_remote.py
+++ b/one/tests/remote/test_remote.py
@@ -439,5 +439,5 @@ class TestGlobusClient(unittest.TestCase):
             self.assertEqual('ERROR', log.records[-1].levelname)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(exit=False)

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -794,11 +794,11 @@ class AlyxClient:
             List of parquet table file paths.
         """
         # query the database for the latest cache; expires=None overrides cached response
-        self.cache_dir.mkdir(exist_ok=True)
         if not self.is_logged_in:
             self.authenticate()
         source = str(source or f'{self.base_url}/cache.zip')
         destination = destination or self.cache_dir
+        Path(destination).mkdir(exist_ok=True, parents=True)
 
         headers = self._headers if source.startswith(self.base_url) else None
         with tempfile.TemporaryDirectory(dir=destination) as tmp:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flake8>=3.7.8
 numpy>=1.18
-pandas>=1.2.4
+pandas>=1.2.4,<2.0.0
 tqdm>=4.32.1
 requests>=2.22.0
 iblutil>=1.1.0


### PR DESCRIPTION
mkdir called on destination instead of default location in AlyxClient.download_cache_tables.