### PR TITLE
V2.0.0

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: setup
       run: |
         sudo apt install pandoc

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false  # Whether to stop execution of other instances
       max-parallel: 2
       matrix:
-        python-version: ["3.8", "3.7"]
+        python-version: ["3.8", "3.11"]
         os: ["ubuntu-latest", "windows-latest"]  #  , "macos-latest"
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - date field of session details a datetime.date object in remote mode (now consistent with local mode)
 - support datasets table without session_path field
 - clearer error message cache directory not available
+- official support of relative path inputs for One.load_dataset(s)
 
 ## [1.21.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 - date field of session details a datetime.date object in remote mode (now consistent with local mode)
 - support datasets table without session_path field
+- clearer error message cache directory not available
 
 ## [1.21.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,25 @@
 
 ### Added
 
+- OneAlyx.list_aggregates method to list datasets computed across more than one session
+- OneAlyx.load_aggregate method to load dataset computed across more than one session
 - one.alf.files.remove_uuid_string, complimenting add_uuid_string
 
 ### Modified
 
 - removed support for integer UUIDs in cache tables
-- support for pandas versions 1.5 - 2.0
-- bugfix: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+- support for pandas versions 1.5 - 2.0; dropped support for Python 3.7
 - date field of session details a datetime.date object in remote mode (now consistent with local mode)
+- support datasets table without session_path field
+- clearer error message when cache directory not available
+- support hyphens in collection part of ALF specification
+- bugfix: safer construction of target directory from dataset URL in OneAlyx._download_dataset
+- bugfix: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 - support datasets table without session_path field
 - clearer error message cache directory not available
 - official support of relative path inputs for One.load_dataset(s)
-- support hyphens in ALF collection spec
 - bugfix: one.webclient.http_download_file returns Path as documented, instead of str
-- deprecated one.alf.io.remove_uuid_file and remove_uuid_recursive in favour of 
+- deprecated one.alf.io.remove_uuid_file and remove_uuid_recursive in favour of one.alf.files.remove_uuid_string
 
 ## [1.21.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - support for pandas versions 1.5 - 2.0
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 - date field of session details a datetime.date object in remote mode (now consistent with local mode)
+- support datasets table without session_path field
 
 ## [1.21.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [1.21.4]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.0.0]
 
 ### Modified
 
+- Removed support for integer UUIDs in cache tables
+- Support for pandas versions 1.5 - 2.0
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 
 ## [1.21.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
 # Changelog
 ## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.0.0]
 
+### Added
+
+- one.alf.files.remove_uuid_string, complimenting add_uuid_string
+
 ### Modified
 
 - removed support for integer UUIDs in cache tables
 - support for pandas versions 1.5 - 2.0
-- HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+- bugfix: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
 - date field of session details a datetime.date object in remote mode (now consistent with local mode)
 - support datasets table without session_path field
 - clearer error message cache directory not available
 - official support of relative path inputs for One.load_dataset(s)
+- support hyphens in ALF collection spec
+- bugfix: one.webclient.http_download_file returns Path as documented, instead of str
+- deprecated one.alf.io.remove_uuid_file and remove_uuid_recursive in favour of 
+
+## [1.21.4]
+
+### Modified
+
+- HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+- HOTFIX: fix error in load_cache when switching from tagged cache
+- frozen pandas below 2.0
 
 ## [1.21.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 
 ### Modified
 
-- Removed support for integer UUIDs in cache tables
-- Support for pandas versions 1.5 - 2.0
+- removed support for integer UUIDs in cache tables
+- support for pandas versions 1.5 - 2.0
 - HOTFIX: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
+- date field of session details a datetime.date object in remote mode (now consistent with local mode)
 
 ## [1.21.3]
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please [Click here](https://int-brain-lab.github.io/ONE/) for the main documenta
 **NB**: The API and backend database are still under active development, for the best experience please regularly update the package by running `pip install -U ONE-api`. 
 
 ## Requirements
-ONE runs on Python 3.7 or later, and is tested on the latest Ubuntu and Windows (3.7 and 3.8 only).
+ONE runs on Python 3.8 or later, and is tested on the latest Ubuntu and Windows (3.8 and 3.11 only).
 
 ## Installing
 Installing the package via pip typically takes a few seconds.  To install, run

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/int-brain-lab/ONE/badge.svg?branch=main)](https://coveralls.io/github/int-brain-lab/ONE?branch=main)
 ![CI workflow](https://github.com/int-brain-lab/ONE/actions/workflows/main.yaml/badge.svg?branch=main)
 
-The Open Neurophysiology Environment is a scheme for sharing neurophysiology data in a standardized manner. For information on how to share data with ONE please [click here](https://github.com/int-brain-lab/ONE/blob/main/docs/Open_Neurophysiology_Environment_Filename_Convention.pdf). This github page contains an API for searching and loading ONE-standardized data, stored either on a user’s local machine or on a remote server. Please [Click here](https://int-brain-lab.github.io/ONE/) for the main documentation page.
+The Open Neurophysiology Environment is a scheme for sharing neurophysiology data in a standardized manner. It is a Python API for searching and loading ONE-standardized data, stored either on a user’s local machine or on a remote server.
+
+Please [Click here](https://int-brain-lab.github.io/ONE/) for the main documentation page.  For a quick primer on the file naming convention we use, [click here](https://github.com/int-brain-lab/ONE/blob/main/docs/Open_Neurophysiology_Environment_Filename_Convention.pdf).
 
 **NB**: The API and backend database are still under active development, for the best experience please regularly update the package by running `pip install -U ONE-api`. 
 
@@ -22,19 +24,20 @@ from one.api import One
 one = One(cache_dir='/home/user/downlaods/ONE/behavior_paper')
 ```
 
+To use the default setup settings that connect you to the [IBL public database](https://openalyx.internationalbrainlab.org):
+```python
+from one.api import ONE
+ONE.setup(silent=True)  # Will use default information
+one = ONE(password='international')
+```
+
 For setting up ONE for a given database e.g. internal IBL Alyx:
 ```python
 from one.api import ONE
 one = ONE(base_url='https://alyx.internationalbrainlab.org')
 ```
 
-To use the default setup settings that connect you to the [IBL public database](https://openalyx.internationalbrainlab.org):
-```python
-from one.api import ONE
-one = ONE(silent=True, password='international')  # Will use default information
-```
-
-Once you've setup the server, subsequent calls will use the same parameters:
+Once you've setup the API for the first time, subsequent calls will use the same parameters:
 ```python
 from one.api import ONE
 one = ONE()
@@ -42,8 +45,8 @@ one = ONE()
 
 To set up ONE for another database and make it the default:
 ```python
-from one.api import OneAlyx, ONE
-OneAlyx.setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
+from one.api import ONE
+ONE.setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
 one = ONE()  # Connected to https://test.alyx.internationalbrainlab.org
 ```
 
@@ -77,6 +80,12 @@ ts = one.load_dataset(eid, 'wheel.timestamps', collection='alf')
 
 # Download, but not load, a dataset
 filename = one.load_dataset(eid, 'wheel.timestamps', download_only=True)
+```
+
+To [share data](https://int-brain-lab.github.io/ONE/notebooks/data_sharing.html):
+```python
+from one.api import One
+one = One.setup()  # Enter the location of the ALF datasets when prompted
 ```
 
 Further examples and tutorials can be found in the [documentation](https://int-brain-lab.github.io/ONE/).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -129,7 +129,7 @@ one.load_cache(tag=TAG)
 ```
 
 ## How do I check which version of ONE I'm using within Python?
-You can check your version with the following: `import one; print(one.__version__)`.\
+You can check your version with the following: `print(ONE.version)`.\
 The latest version can be found in the CHANGELOG, [here](https://github.com/int-brain-lab/ONE/blob/main/CHANGELOG.md). \
 To update to the latest available version run `pip install -U ONE-api`.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -118,14 +118,20 @@ site you are attempting to access with ONE (no need to log in)
 This is a unique issue with the way that the Windows OS handles certificates.
 
 ## How do I download the datasets cache for a specific IBL paper release?
-With OpenAlyx you have the ability to download cache tables containing datasets with a specific release tag.
+You can download cache tables containing datasets with a specific release tag.
 
 ```python
 from one.api import ONE
 
-one = ONE(base_url='https://openalyx.internationalbrainlab.org', password='international', silent=True)
+one = ONE()
 TAG = '2021_Q1_IBL_et_al_Behaviour'  # Release tag to download cache for
 one.load_cache(tag=TAG)
+```
+
+To return to the full cache containing an index of all experiments:
+```python
+ONE.cache_clear()
+one = ONE()
 ```
 
 ## How do I check which version of ONE I'm using within Python?

--- a/docs/notebooks/one_list/one_list.ipynb
+++ b/docs/notebooks/one_list/one_list.ipynb
@@ -480,6 +480,40 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Listing aggregate datasets\n",
+    "All raw and preprocessed data are stored at the session level, however some datasets are aggregated\n",
+    "over a subject, project, or tag (called a 'relation'). Such datasets are known as aggregates and\n",
+    "can be listed and filtered using the `list_aggregates` method. Unlike `list_datasets`, `list_aggregates`\n",
+    "always returns a pandas DataFrame object.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "Note.\n",
+    "\n",
+    "NB: This method is only available in 'remote' mode.\n",
+    "</div>"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "subject = 'SWC_043'\n",
+    "subject_aggregates = one.list_aggregates('subjects', subject)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/docs/notebooks/one_load/one_load.ipynb
+++ b/docs/notebooks/one_load/one_load.ipynb
@@ -676,6 +676,39 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Loading aggregate datasets\n",
+    "All raw and preprocessed data are stored at the session level, however some datasets are aggregated\n",
+    "over a subject, project, or tag (called a 'relation'). Such datasets can be loaded using the `load_aggregate`\n",
+    "method.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "Note.\n",
+    "\n",
+    "NB: This method is only available in 'remote' mode.\n",
+    "</div>"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "subject = 'SWC_043'\n",
+    "subject_trials = one.load_aggregate('subjects', subject, '_ibl_subjectTrials.table')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/docs/notebooks/one_load/one_load.ipynb
+++ b/docs/notebooks/one_load/one_load.ipynb
@@ -505,6 +505,36 @@
   {
    "cell_type": "markdown",
    "source": [
+    "### Loading with relative paths\n",
+    "You may also the complete dataset path, relative to the session path. When doing this the path must\n",
+    "be complete (i.e. without wildcards) and the collection and revision arguments must be None.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "Note.\n",
+    "\n",
+    "To ensure you're loading the default revision (usually the most recent and correct data), do not\n",
+    "explicitly provide the relative path or revision, and ONE will return the default automatically.\n",
+    "</div>\n",
+    "\n",
+    "```python\n",
+    "spikes_times = one.load_dataset(eid, 'alf/probe00/spikes.times.npy')\n",
+    "```\n",
+    "\n",
+    "Download all the raw data for a given session*\n",
+    "```python\n",
+    "dsets = one.list_datasets(eid, collection='raw_*_data')\n",
+    "one.load_datasets(eid, dsets, download_only=True)\n",
+    "```\n",
+    "*NB: This will download all revisions of the same data; for this reason it is better to objects and\n",
+    "collections individually, or to provide dataset names instead of relative paths."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "## Loading with timeseries\n",
     "For loading a dataset along with its timestamps, alf.io.read_ts can be used. It requires a\n",
     "filepath as input."

--- a/docs/notebooks/one_modes.ipynb
+++ b/docs/notebooks/one_modes.ipynb
@@ -183,12 +183,28 @@
    "cell_type": "markdown",
    "source": [
     "Caching greatly improves performance and should be used whenever possible.\n",
-    "For more information on ONE REST queries, see [this guide](./one_advanced/one_advanced.html)."
+    "For more information on ONE REST queries, see [this guide](./one_advanced/one_advanced.html).\n",
+    "\n",
+    "You can turn off REST caching when instantiating ONE with the `cache_rest` keyword argument:"
    ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "one = ONE(cache_rest=None, mode='remote')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
     }
    }
   },
@@ -276,10 +292,10 @@
     "\n",
     "\\*no remote cache tables are downloaded; local cache files must be present in this mode.\n",
     "\n",
-    "**I want to make a REST query for up-to-the-minute information**  \n",
+    "**I want to make a REST query for up-to-the-minute information**\n",
     "Use `one.alyx.rest(..., no_cache=True)`.\n",
     "\n",
-    "**I want to use a remote ONE query with up-to-the-minute information**  \n",
+    "**I want to use a remote ONE query with up-to-the-minute information**\n",
     "Call the ONE method from within the `webclient.no_cache` context."
    ],
    "metadata": {

--- a/docs/notebooks/one_quickstart.ipynb
+++ b/docs/notebooks/one_quickstart.ipynb
@@ -38,7 +38,8 @@
    "outputs": [],
    "source": [
     "from one.api import ONE\n",
-    "one = ONE(base_url='https://openalyx.internationalbrainlab.org', password='international', silent=True)"
+    "ONE.setup(base_url='https://openalyx.internationalbrainlab.org', silent=True)\n",
+    "one = ONE(password='international')"
    ]
   },
   {

--- a/docs/notebooks/useful_alyx_queries.ipynb
+++ b/docs/notebooks/useful_alyx_queries.ipynb
@@ -81,6 +81,30 @@
     "`rest_schemas` property.  For example, for the parameters available for listing sessions..."
    ],
    "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print(one.alyx.rest_schemes['sessions']['list']['description'])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This information is also available using the `print_endpoint_info` method, which prints the REST\n",
+    "params and their respective data types:"
+   ],
+   "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
@@ -137,7 +161,7 @@
     }
    ],
    "source": [
-    "print(one.alyx.rest_schemes['sessions']['list']['description'])"
+    "one.alyx.print_endpoint_info('sessions', action='list');"
    ],
    "metadata": {
     "collapsed": false,

--- a/docs/one_installation.md
+++ b/docs/one_installation.md
@@ -68,3 +68,12 @@ To update, open a shell terminal, activate the environment `iblenv` and launch t
 ```python
 pip install -U ONE-api
 ```
+
+You can check the API version with Python one of two ways:
+```python
+from one.api import ONE
+print(ONE.version)
+
+from one import __version__
+print(__version__)
+```

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API"""
-__version__ = '1.21.4'
+__version__ = '2.0.0'

--- a/one/alf/files.py
+++ b/one/alf/files.py
@@ -371,19 +371,37 @@ def get_alf_path(path: Union[str, Path]) -> str:
 
 def add_uuid_string(file_path, uuid):
     """
-    Add a UUID and an extra part to the filename of an ALF path
+    Add a UUID to the filename of an ALF path.
+
+    Adds a UUID to an ALF filename as an extra part, e.g.
+    'obj.attr.ext' -> 'obj.attr.a976e418-c8b8-4d24-be47-d05120b18341.ext'.
 
     Parameters
     ----------
     file_path : str, pathlib.Path, pathlib.PurePath
-        An ALF path to add the UUID to
+        An ALF path to add the UUID to.
     uuid : str, uuid.UUID
-        The UUID to add
+        The UUID to add.
 
     Returns
     -------
-    pathlib.Path
-        A new Path object with a UUID in the filename
+    pathlib.Path, pathlib.PurePath
+        A new Path or PurePath object with a UUID in the filename.
+
+    Examples
+    --------
+    >>> add_uuid_string('/path/to/trials.intervals.npy', 'a976e418-c8b8-4d24-be47-d05120b18341')
+    Path('/path/to/trials.intervals.a976e418-c8b8-4d24-be47-d05120b18341.npy')
+
+    Raises
+    ------
+    ValueError
+        `uuid` must be a valid hyphen-separated hexadecimal UUID.
+
+    See Also
+    --------
+    one.alf.io.remove_uuid_string
+    one.alf.spec.is_uuid
     """
     if isinstance(uuid, str) and not spec.is_uuid_string(uuid):
         raise ValueError('Should provide a valid UUID v4')
@@ -396,3 +414,38 @@ def add_uuid_string(file_path, uuid):
         _logger.warning(f'UUID already found in file name: {file_path.name}: IGNORE')
         return file_path
     return file_path.parent.joinpath(f"{'.'.join(name_parts)}.{uuid}{file_path.suffix}")
+
+
+def remove_uuid_string(file_path):
+    """
+    Remove UUID from a filename of an ALF path.
+
+    Parameters
+    ----------
+    file_path : str, pathlib.Path, pathlib.PurePath
+        An ALF path to add the UUID to.
+
+    Returns
+    -------
+    pathlib.Path, pathlib.PurePath
+        A new Path or PurePath object without a UUID in the filename.
+
+    Examples
+    --------
+    >>> add_uuid_string('/path/to/trials.intervals.a976e418-c8b8-4d24-be47-d05120b18341.npy')
+    Path('/path/to/trials.intervals.npy')
+
+    >>> add_uuid_string('/path/to/trials.intervals.npy')
+    Path('/path/to/trials.intervals.npy')
+
+    See Also
+    --------
+    one.alf.io.add_uuid_string
+    """
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+    name_parts = file_path.stem.split('.')
+
+    if spec.is_uuid_string(name_parts[-1]):
+        file_path = file_path.with_name('.'.join(name_parts[:-1]) + file_path.suffix)
+    return file_path

--- a/one/alf/io.py
+++ b/one/alf/io.py
@@ -14,6 +14,7 @@ import re
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Union
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -634,15 +635,27 @@ def save_metadata(file_alf, dico) -> None:
 
 def remove_uuid_file(file_path, dry=False) -> Path:
     """
-    Renames a file without the UUID and returns the new pathlib.Path object
+    (DEPRECATED) Renames a file without the UUID and returns the new pathlib.Path object.
+
+    Parameters
+    ----------
+    file_path : str, pathlib.Path
+        An ALF path containing a UUID in the file name.
+    dry : bool
+        If False, the file is not renamed on disk.
+
+    Returns
+    -------
+    pathlib.Path
+        The new file path without the UUID in the file name.
     """
-    if isinstance(file_path, str):
-        file_path = Path(file_path)
-    name_parts = file_path.name.split('.')
-    if not spec.is_uuid_string(name_parts[-2]):
-        return file_path
-    name_parts.pop(-2)
-    new_path = file_path.parent.joinpath('.'.join(name_parts))
+    warnings.warn(
+        'remove_uuid_file deprecated, use one.alf.files.remove_uuid_string instead',
+        DeprecationWarning)
+    file_path = Path(file_path)
+    new_path = files.remove_uuid_string(file_path)
+    if new_path == file_path:
+        return new_path
     if not dry and file_path.exists():
         file_path.replace(new_path)
     return new_path
@@ -650,8 +663,18 @@ def remove_uuid_file(file_path, dry=False) -> Path:
 
 def remove_uuid_recursive(folder, dry=False) -> None:
     """
-    Within a folder, recursive renaming of all files to remove UUID
+    (DEPRECATED) Within a folder, recursive renaming of all files to remove UUID.
+
+    Parameters
+    ----------
+    folder : str, pathlib.Path
+        A folder to recursively iterate, removing UUIDs from the file names.
+    dry : bool
+        If False renames the files on disk.
     """
+    warnings.warn(
+        'remove_uuid_recursive is deprecated and will be removed in the next release',
+        DeprecationWarning)
     for fn in Path(folder).rglob('*.*'):
         print(remove_uuid_file(fn, dry=dry))
 

--- a/one/alf/spec.py
+++ b/one/alf/spec.py
@@ -110,7 +110,7 @@ _DEFAULT = (
     ('subject', r'[\w-]+'),
     ('date', r'\d{4}-\d{2}-\d{2}'),
     ('number', r'\d{1,3}'),
-    ('collection', r'[\w/]+'),
+    ('collection', r'[\w/-]+'),
     ('revision', r'[\w-]+'),  # brackets
     # to include underscores: r'(?P<namespace>(?:^_)\w+(?:_))?'
     ('namespace', '(?<=_)[a-zA-Z0-9]+'),  # brackets

--- a/one/api.py
+++ b/one/api.py
@@ -143,6 +143,8 @@ class One(ConversionMixin):
             meta['expired'] = True
             meta['raw'] = {}
             self._cache.update({'datasets': pd.DataFrame(), 'sessions': pd.DataFrame()})
+            if self.offline:  # In online mode, the cache tables should be downloaded later
+                warnings.warn(f'No cache tables found in {self._tables_dir}')
         created = [datetime.fromisoformat(x['date_created'])
                    for x in meta['raw'].values() if 'date_created' in x]
         if created:
@@ -1497,6 +1499,13 @@ class OneAlyx(One):
             _logger.debug(ex)
             _logger.error(f'{type(ex).__name__}: Failed to connect to Alyx')
             self.mode = 'local'
+        except FileNotFoundError as ex:
+            # NB: this error is only raised in online mode
+            raise ex from FileNotFoundError(
+                f'Cache directory not accessible: {tables_dir or self.cache_dir}\n'
+                'Please provide valid tables_dir / cache_dir kwargs '
+                'or run ONE.setup to update the default directory.'
+            )
 
     @property
     def alyx(self):

--- a/one/api.py
+++ b/one/api.py
@@ -1825,7 +1825,7 @@ class OneAlyx(One):
         def _add_date(records):
             """Add date field for compatibility with One.search output."""
             for s in util.ensure_list(records):
-                s['date'] = str(datetime.fromisoformat(s['start_time']).date())
+                s['date'] = datetime.fromisoformat(s['start_time']).date()
             return records
 
         return eids, util.LazyId(ses, func=_add_date)

--- a/one/api.py
+++ b/one/api.py
@@ -649,25 +649,25 @@ class One(ConversionMixin):
             Experiment session identifier; may be a UUID, URL, experiment reference string
             details dict or Path.
         filename : str, dict, list
-            Filters datasets and returns only the ones matching the filename
+            Filters datasets and returns only the ones matching the filename.
             Supports lists asterisks as wildcards.  May be a dict of ALF parts.
         collection : str, list
             The collection to which the object belongs, e.g. 'alf/probe01'.
             This is the relative path of the file from the session root.
             Supports asterisks as wildcards.
         revision : str
-            Filters datasets and returns only the ones matching the revision
-            Supports asterisks as wildcards
+            Filters datasets and returns only the ones matching the revision.
+            Supports asterisks as wildcards.
         details : bool
             When true, a pandas DataFrame is returned, otherwise a numpy array of
             relative paths (collection/revision/filename) - see one.alf.spec.describe for details.
         query_type : str
-            Query cache ('local') or Alyx database ('remote')
+            Query cache ('local') or Alyx database ('remote').
 
         Returns
         -------
         np.ndarray, pd.DataFrame
-            Slice of datasets table or numpy array if details is False
+            Slice of datasets table or numpy array if details is False.
 
         Examples
         --------
@@ -1503,7 +1503,7 @@ class OneAlyx(One):
         raw_meta = cache_meta.get('raw', {}).values() or [{}]
         # If user provides tag that doesn't match current cache's tag, always download.
         # NB: In the future 'database_tags' may become a list.
-        current_tags = [x.get('database_tags') for x in raw_meta]
+        current_tags = flatten(x.get('database_tags') for x in raw_meta)
         if len(set(filter(None, current_tags))) > 1:
             raise NotImplementedError(
                 'Loading cache tables with multiple tags is not currently supported'
@@ -1800,6 +1800,16 @@ class OneAlyx(One):
         (list of dicts)
             If details is True, also returns a list of dictionaries, each entry corresponding to a
             matching insertion.
+
+        Notes
+        -----
+        - This method does not use the local cache and therefore can not work in 'local' mode.
+
+        Examples
+        --------
+        List the insertions associated with a given data release
+        >>> tag = '2022_Q2_IBL_et_al_RepeatedSite'
+        ... ins = one.search_insertions(django='datasets__tags__name,' + tag)
         """
         query_type = query_type or self.mode
         if query_type == 'local' and 'insertions' not in self._cache.keys():

--- a/one/api.py
+++ b/one/api.py
@@ -524,7 +524,7 @@ class One(ConversionMixin):
                 _dsets = self._cache['datasets'][
                     self._cache['datasets'].index.get_level_values(1).isin(datasets.index)
                 ]
-                idx =_dsets.index.get_level_values(1)
+                idx = _dsets.index.get_level_values(1)
             else:
                 _dsets = datasets
                 idx = pd.IndexSlice[:, _dsets.index.get_level_values(1)]
@@ -981,10 +981,31 @@ class One(ConversionMixin):
 
         >>> intervals = one.load_dataset(eid, 'trials.intervals')  # wildcard mode only
         >>> intervals = one.load_dataset(eid, '.*trials.intervals.*')  # regex mode only
+        >>> intervals = one.load_dataset(eid, dict(object='trials', attribute='intervals'))
         >>> filepath = one.load_dataset(eid, '_ibl_trials.intervals.npy', download_only=True)
         >>> spike_times = one.load_dataset(eid, 'spikes.times.npy', collection='alf/probe01')
         >>> old_spikes = one.load_dataset(eid, 'spikes.times.npy',
         ...                               collection='alf/probe01', revision='2020-08-31')
+        >>> old_spikes = one.load_dataset(eid, 'alf/probe01/#2020-08-31#/spikes.times.npy')
+
+        Raises
+        ------
+        ValueError
+            When a relative paths is provided (e.g. 'collection/#revision#/object.attribute.ext'),
+            the collection and revision keyword arguments must be None.
+        one.alf.exceptions.ALFObjectNotFound
+            The dataset was not found in the cache or on disk.
+        one.alf.exceptions.ALFMultipleCollectionsFound
+            The dataset provided exists in multiple collections or matched multiple different
+            files. Provide a specific collection to load, and make sure any wildcard/regular
+            expressions are specific enough.
+
+        Warnings
+        --------
+        UserWarning
+            When a relative paths is provided (e.g. 'collection/#revision#/object.attribute.ext'),
+            wildcards/regular expressions must not be used. To use wildcards, pass the collection
+            and revision as separate keyword arguments.
         """
         datasets = self.list_datasets(eid, details=True, query_type=query_type or self.mode)
         # If only two parts and wildcards are on, append ext wildcard
@@ -992,8 +1013,15 @@ class One(ConversionMixin):
             dataset += '.*'
             _logger.info('Appending extension wildcard: ' + dataset)
 
+        assert_unique = ('/' if isinstance(dataset, str) else 'collection') not in dataset
+        # Check if wildcard was used (this is not an exhaustive check)
+        if not assert_unique and isinstance(dataset, str) and '*' in dataset:
+            warnings.warn('Wildcards should not be used with relative path as input.')
+        if not assert_unique and (collection is not None or revision is not None):
+            raise ValueError(
+                'collection and revision kwargs must be None when dataset is a relative path')
         datasets = util.filter_datasets(datasets, dataset, collection, revision,
-                                        wildcards=self.wildcards)
+                                        wildcards=self.wildcards, assert_unique=assert_unique)
         if len(datasets) == 0:
             raise alferr.ALFObjectNotFound(f'Dataset "{dataset}" not found')
 
@@ -1052,6 +1080,42 @@ class One(ConversionMixin):
             A list of data (or file paths) the length of datasets
         list
             A list of meta data Bunches. If assert_present is False, missing data will be None
+
+        Notes
+        -----
+        - There are three ways the datasets may be formatted: the object.attribute; the file name
+         (including namespace and extension); the ALF components as a dict; the dataset path,
+         relative to the session path, e.g. collection/object.attribute.ext.
+        - When relative paths are provided (e.g. 'collection/#revision#/object.attribute.ext'),
+         wildcards/regular expressions must not be used. To use wildcards, pass the collection and
+         revision as separate keyword arguments.
+        - To ensure you are loading the correct revision, use the revisions kwarg instead of
+         relative paths.
+
+        Raises
+        ------
+        ValueError
+            When a relative paths is provided (e.g. 'collection/#revision#/object.attribute.ext'),
+            the collection and revision keyword arguments must be None.
+        ValueError
+            If a list of collections or revisions are provided, they must match the number of
+            datasets passed in.
+        TypeError
+            The datasets argument must be a non-string iterable.
+        one.alf.exceptions.ALFObjectNotFound
+            One or more of the datasets was not found in the cache or on disk.  To suppress this
+            error and return None for missing datasets, use assert_present=False.
+        one.alf.exceptions.ALFMultipleCollectionsFound
+            One or more of the dataset(s) provided exist in multiple collections. Provide the
+            specific collections to load, and if using wildcards/regular expressions, make sure
+            the expression is specific enough.
+
+        Warnings
+        --------
+        UserWarning
+            When providing a list of relative dataset paths, this warning occurs if one or more
+            of the datasets are not marked as default revisions.  Avoid such warnings by explicitly
+            passing in the required revisions with the revisions keyword argument.
         """
 
         def _verify_specifiers(specifiers):
@@ -1088,10 +1152,27 @@ class One(ConversionMixin):
         if self.wildcards:  # Append extension wildcard if 'object.attribute' string
             datasets = [x + ('.*' if isinstance(x, str) and len(x.split('.')) == 2 else '')
                         for x in datasets]
-        slices = [util.filter_datasets(all_datasets, x, y, z, wildcards=self.wildcards)
+        # If collections provided in datasets list, e.g. [collection/x.y.z], do not assert unique
+        validate = not any(('/' if isinstance(d, str) else 'collection') in d for d in datasets)
+        if not validate and not all(x is None for x in collections + revisions):
+            raise ValueError(
+                'collection and revision kwargs must be None when dataset is a relative path')
+        ops = dict(wildcards=self.wildcards, assert_unique=validate)
+        slices = [util.filter_datasets(all_datasets, x, y, z, **ops)
                   for x, y, z in zip(datasets, collections, revisions)]
         present = [len(x) == 1 for x in slices]
         present_datasets = pd.concat(slices)
+
+        # Check if user is blindly downloading all data and warn of non-default revisions
+        if 'default_revision' in present_datasets and \
+                not any(revisions) and not all(present_datasets['default_revision']):
+            old = present_datasets.loc[~present_datasets['default_revision'], 'rel_path'].to_list()
+            warnings.warn(
+                'The following datasets may have been revised and ' +
+                'are therefore not recommended for analysis:\n\t' +
+                '\n\t'.join(old) + '\n'
+                'To avoid this warning, specify the revision as a kwarg or use load_dataset.'
+            )
 
         if not all(present):
             missing_list = ', '.join(x for x, y in zip(datasets, present) if not y)

--- a/one/api.py
+++ b/one/api.py
@@ -329,8 +329,6 @@ class One(ConversionMixin):
         else:
             name = 'dataset_uuid'
             ids = self._cache['_loaded_datasets']
-            if ids.dtype != '<U36':
-                ids = parquet.np2str(ids)
 
         timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S%z")
         filename = Path(self._tables_dir or self.cache_dir) / f'{timestamp}_loaded_{name}s.csv'
@@ -1236,8 +1234,6 @@ class One(ConversionMixin):
             dset_id, = parquet.np2str(dset_id)
         try:
             dataset = self._cache['datasets'].loc[(slice(None), dset_id), :].squeeze()
-            if dataset.empty:
-                raise alferr.ALFObjectNotFound('Dataset not found')
             assert isinstance(dataset, pd.Series) or len(dataset) == 1
         except AssertionError:
             raise alferr.ALFMultipleObjectsFound('Duplicate dataset IDs')

--- a/one/converters.py
+++ b/one/converters.py
@@ -21,9 +21,8 @@ import pandas as pd
 from iblutil.io import parquet
 from iblutil.util import Bunch
 
-import one.alf.io as alfio
 from one.alf.spec import is_session_path, is_uuid_string
-from one.alf.files import get_session_path, add_uuid_string, session_path_parts
+from one.alf.files import get_session_path, add_uuid_string, session_path_parts, remove_uuid_string
 from .util import Listable, ensure_list
 
 
@@ -256,7 +255,7 @@ class ConversionMixin:
         if isinstance(path, str) and path.startswith('http'):
             # Remove the UUID from path
             path = urlsplit(path).path.strip('/')
-            path = alfio.remove_uuid_file(PurePosixPath(path), dry=True)
+            path = remove_uuid_string(PurePosixPath(path))
             session_path = get_session_path(path).as_posix()
         else:
             # No way of knowing root session path parts without cache tables
@@ -671,9 +670,7 @@ def path_from_filerecord(fr, root_path=PurePosixPath('/'), uuid=None):
     """
     if isinstance(fr, list):
         return [path_from_filerecord(f) for f in fr]
-    repo_path = fr['data_repository_path']
-    repo_path = repo_path[repo_path.startswith('/'):]  # remove starting / if any
-    # repo_path = (p := fr['data_repository_path'])[p[0] == '/':]  # py3.8 Remove slash at start
+    repo_path = (p := fr['data_repository_path'])[p[0] == '/':]  # Remove slash at start, if any
     file_path = PurePosixPath(repo_path, fr['relative_path'])
     if root_path:
         # NB: By checking for string we won't cast any PurePaths

--- a/one/converters.py
+++ b/one/converters.py
@@ -175,8 +175,6 @@ class ConversionMixin:
             return
 
         # load path from cache
-        if self._index_type() is int:
-            eid = parquet.str2np(eid).tolist()
         try:
             ses = self._cache['sessions'].loc[eid].squeeze()
             assert isinstance(ses, pd.Series), 'Duplicate eids in sessions table'

--- a/one/registration.py
+++ b/one/registration.py
@@ -270,6 +270,7 @@ class RegistrationClient:
         """
         date = date or datetime.datetime.now()  # If None get current time
         if isinstance(date, str):
+            # FIXME support timezone aware strings, e.g. '2023-03-09T17:08:12.4465024+00:00'
             date = datetime.datetime.fromisoformat(date)  # Validate by parsing
         elif type(date) is datetime.date:
             date = datetime.datetime.fromordinal(date.toordinal())

--- a/one/remote/globus.py
+++ b/one/remote/globus.py
@@ -12,7 +12,7 @@ from globus_sdk import TransferAPIError, GlobusAPIError, NetworkError, GlobusTim
 from iblutil.io import params as iopar
 
 from one.alf.spec import is_uuid
-from one.alf.io import remove_uuid_file
+from one.alf.files import remove_uuid_string
 import one.params
 from one.webclient import AlyxClient
 from .base import DownloadClient, load_client_params, save_client_params
@@ -413,9 +413,7 @@ class Globus(DownloadClient):
                 if i == max_retries:
                     raise ex
         for entry in response:
-            fn = PurePosixPath(
-                remove_uuid_file(entry['name'], dry=True) if remove_uuid else entry['name']
-            )
+            fn = PurePosixPath(remove_uuid_string(entry['name']) if remove_uuid else entry['name'])
             if return_size:
                 size = entry['size'] if entry['type'] == 'file' else None
                 out.append((fn, size))

--- a/one/tests/alf/test_alf_files.py
+++ b/one/tests/alf/test_alf_files.py
@@ -149,7 +149,7 @@ class TestAlfParse(unittest.TestCase):
             self.assertEqual(o, files._isdatetime(i))
 
     def test_add_uuid(self):
-        """Test for one.alf.files.add_uuid"""
+        """Test for one.alf.files.add_uuid_string."""
         _uuid = uuid.uuid4()
 
         file_with_uuid = f'/titi/tutu.part1.part1.{_uuid}.json'
@@ -162,6 +162,21 @@ class TestAlfParse(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             files.add_uuid_string('/foo/bar.npy', 'fake')
+
+    def test_remove_uuid(self):
+        """Test for one.alf.files.remove_uuid_string."""
+        # First test with full file
+        file_path = '/tmp/Subjects/CSHL063/2020-09-12/001/raw_ephys_data/probe00/' \
+                    '_spikeglx_sync.channels.probe00.89c861ea-66aa-4729-a808-e79f84d08b81.npy'
+        desired_output = Path(file_path).with_name('_spikeglx_sync.channels.probe00.npy')
+        files.remove_uuid_string(file_path)
+        self.assertEqual(desired_output, files.remove_uuid_string(file_path))
+        self.assertEqual(desired_output, files.remove_uuid_string(desired_output))
+
+        # Test with just file name
+        file_path = 'toto.89c861ea-66aa-4729-a808-e79f84d08b81.npy'
+        desired_output = Path('toto.npy')
+        self.assertEqual(desired_output, files.remove_uuid_string(file_path))
 
 
 class TestALFGet(unittest.TestCase):

--- a/one/tests/alf/test_alf_spec.py
+++ b/one/tests/alf/test_alf_spec.py
@@ -17,7 +17,7 @@ class TestALFSpec(unittest.TestCase):
         verifiable = alf_spec.regex()
         expected = ('((?P<lab>\\w+)/Subjects/)?'
                     '(?P<subject>[\\w-]+)/(?P<date>\\d{4}-\\d{2}-\\d{2})/(?P<number>\\d{1,3})/'
-                    '((?P<collection>[\\w/]+)/)?(#(?P<revision>[\\w-]+)#/)?'
+                    '((?P<collection>[\\w/-]+)/)?(#(?P<revision>[\\w-]+)#/)?'
                     '_?(?P<namespace>(?<=_)[a-zA-Z0-9]+)?_?(?P<object>\\w+)\\.'
                     '(?P<attribute>(?:_[a-z]+_)?[a-zA-Z0-9]+'
                     '(?:_times(?=[_.])|_intervals(?=[_.]))?)'

--- a/one/tests/alf/test_cache.py
+++ b/one/tests/alf/test_cache.py
@@ -178,5 +178,5 @@ class TestsONEParquet(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main(exit=False)

--- a/one/tests/test_alyxrest.py
+++ b/one/tests/test_alyxrest.py
@@ -16,7 +16,7 @@ from one.tests import TEST_DB_1, OFFLINE_ONLY
 
 @unittest.skipIf(OFFLINE_ONLY, 'online only test')
 class TestREST(unittest.TestCase):
-    """Tests for AlyxClient.rest method and remote Alyx REST interations."""
+    """Tests for AlyxClient.rest method and remote Alyx REST interactions."""
     EID = 'cf264653-2deb-44cb-aa84-89b82507028a'
     EID_EPHYS = 'b1c968ad-4874-468d-b2e4-5ffa9b9964e9'
     alyx = None

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -77,8 +77,8 @@ class TestConverters(unittest.TestCase):
         """Test for ConversionMixin.eid2path"""
         eid = 'd3372b15-f696-4279-9be5-98f15783b5bb'
         verifiable = self.one.eid2path(eid)
-        expected = Path(self.tempdir.name).joinpath('mainenlab', 'Subjects', 'ZFM-01935',
-                                                    '2021-02-05', '001')
+        expected = Path(self.tempdir.name).joinpath(
+            'mainenlab', 'Subjects', 'ZFM-01935', '2021-02-05', '001')
         self.assertEqual(expected, verifiable)
 
         with self.assertRaises(ValueError):
@@ -93,17 +93,6 @@ class TestConverters(unittest.TestCase):
         # Test short circuit
         with mock.patch.object(self.one._cache, 'sessions', new=pd.DataFrame([])):
             self.assertIsNone(self.one.eid2path(eid))
-
-        # Test with int ids
-        old_cache = self.one._cache.copy()
-        util.caches_str2int(self.one._cache)
-        try:
-            verifiable = self.one.eid2path(eid)
-            expected = Path(self.tempdir.name).joinpath(
-                'mainenlab', 'Subjects', 'ZFM-01935', '2021-02-05', '001')
-            self.assertEqual(verifiable, expected)
-        finally:
-            self.one._cache = old_cache
 
     def test_eid2ref(self):
         eid = 'd3372b15-f696-4279-9be5-98f15783b5bb'

--- a/one/tests/test_converters.py
+++ b/one/tests/test_converters.py
@@ -248,6 +248,8 @@ class TestOnlineConverters(unittest.TestCase):
         expected = 'https://ibl.flatironinstitute.org/public/' \
                    'hoferlab/Subjects/SWC_043/2020-09-21/001'
         self.assertEqual(expected, url)
+        # Check type checking
+        self.assertRaises(TypeError, self.one.record2url, rec.to_dict())
 
     def test_record2path(self):
         """Test for ConversionMixin.record2path"""

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -270,7 +270,7 @@ class TestRegistrationClient(unittest.TestCase):
         r, = self.client.register_files(file_list=[file])
         self.assertEqual(r['revision'], rev['name'])
         self.assertTrue(r['default'])
-        self.assertEqual(r['collection'], '')
+        self.assertIsNone(r['collection'])
 
         # Register exact dataset revision again - it should append an 'a'
         # When we re-register the original it should move them into revision with today's date

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -347,8 +347,7 @@ class TestRegistrationClient(unittest.TestCase):
             [x.touch() for x in files]
             self.client.register_files(file_list=files)
             self.assertEqual(2, alyx_mock.call_count)
-            _, kwargs = alyx_mock.call_args
-            actual = kwargs.get('data', {}).get('filenames', [])
+            actual = alyx_mock.call_args.kwargs.get('data', {}).get('filenames', [])
             expected = [
                 'wheel.position.ssv',
                 f'#{today}#/wheel.position.npy',

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -148,6 +148,7 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
         'session_path': 'subject/1900-01-01/001',
         'file_size': None,
         'hash': None,
+        'exists': True,
         'eid': str(uuid4()),
         'id': map(str, (uuid4() for _ in rel_path))
     }

--- a/one/util.py
+++ b/one/util.py
@@ -432,7 +432,9 @@ def filter_revision_last_before(datasets, revision=None, assert_unique=True):
                 raise alferr.ALFMultipleRevisionsFound(rev_list)
             if sum(df.default_revision) == 1:
                 return df[df.default_revision]
-            # default_revision column all False; default doesn't isn't copied to remote repository
+            if len(df) == 1:  # This may be the case when called from load_datasets
+                return df  # It's not the default be there's only one available revision
+            # default_revision column all False; default isn't copied to remote repository
             dset_name = df['rel_path'].iloc[0]
             if assert_unique:
                 raise alferr.ALFError(f'No default revision for dataset {dset_name}')

--- a/one/util.py
+++ b/one/util.py
@@ -13,9 +13,8 @@ import numpy as np
 from packaging import version
 
 import one.alf.exceptions as alferr
-from one.alf.files import rel_path_parts, get_session_path, get_alf_path
+from one.alf.files import rel_path_parts, get_session_path, get_alf_path, remove_uuid_string
 from one.alf.spec import FILE_SPEC, regex as alf_regex
-import one.alf.io as alfio
 
 logger = logging.getLogger(__name__)
 
@@ -25,27 +24,23 @@ def Listable(t):
     return Union[t, Sequence[t]]
 
 
-def ses2records(ses: dict, int_id=False):
+def ses2records(ses: dict):
     """Extract session cache record and datasets cache from a remote session data record.
 
     Parameters
     ----------
     ses : dict
-        Session dictionary from Alyx REST endpoint
-    int_id : bool
-        If True, the UUIDs are converted to two int64s
+        Session dictionary from Alyx REST endpoint.
 
     Returns
     -------
     pd.Series
-        Session record
+        Session record.
     pd.DataFrame
-        Datasets frame
+        Datasets frame.
     """
     # Extract session record
     eid = ses['url'][-36:]
-    if int_id:
-        eid = tuple(parquet.str2np(eid).flatten())
     session_keys = ('subject', 'start_time', 'lab', 'number', 'task_protocol', 'projects')
     session_data = {k: v for k, v in ses.items() if k in session_keys}
     session = (
@@ -57,14 +52,10 @@ def ses2records(ses: dict, int_id=False):
     # Extract datasets table
     def _to_record(d):
         rec = dict(file_size=d['file_size'], hash=d['hash'], exists=True)
-        if int_id:
-            rec['id_0'], rec['id_1'] = parquet.str2np(d['id']).flatten().tolist()
-            rec['eid_0'], rec['eid_1'] = session.name
-        else:
-            rec['id'] = d['id']
-            rec['eid'] = session.name
+        rec['id'] = d['id']
+        rec['eid'] = session.name
         file_path = urllib.parse.urlsplit(d['data_url'], allow_fragments=False).path.strip('/')
-        file_path = get_alf_path(alfio.remove_uuid_file(file_path, dry=True))
+        file_path = get_alf_path(remove_uuid_string(file_path))
         rec['session_path'] = get_session_path(file_path).as_posix()
         rec['rel_path'] = file_path[len(rec['session_path']):].strip('/')
         rec['default_revision'] = d['default_revision'] == 'True'
@@ -73,25 +64,25 @@ def ses2records(ses: dict, int_id=False):
     if not ses.get('data_dataset_session_related'):
         return session, pd.DataFrame()
     records = map(_to_record, ses['data_dataset_session_related'])
-    index = ['eid_0', 'eid_1', 'id_0', 'id_1'] if int_id else ['eid', 'id']
+    index = ['eid', 'id']
     datasets = pd.DataFrame(records).set_index(index).sort_index()
     return session, datasets
 
 
-def datasets2records(datasets, int_id=False) -> pd.DataFrame:
-    """Extract datasets DataFrame from one or more Alyx dataset records
+def datasets2records(datasets, additional=None) -> pd.DataFrame:
+    """Extract datasets DataFrame from one or more Alyx dataset records.
 
     Parameters
     ----------
     datasets : dict, list
-        One or more records from the Alyx 'datasets' endpoint
+        One or more records from the Alyx 'datasets' endpoint.
+    additional : list of str
+        A set of optional fields to extract from dataset records.
 
     Returns
     -------
     pd.DataFrame
-        Datasets frame
-    int_id : bool
-        If True, the UUIDs are converted to two int64s
+        Datasets frame.
 
     Examples
     --------
@@ -105,21 +96,21 @@ def datasets2records(datasets, int_id=False) -> pd.DataFrame:
         if not file_record:
             continue  # Ignore files that are not accessible
         rec = dict(file_size=d['file_size'], hash=d['hash'], exists=True)
-        if int_id:
-            rec['id_0'], rec['id_1'] = parquet.str2np(d['url'][-36:]).flatten().tolist()
-            rec['eid_0'], rec['eid_1'] = parquet.str2np(d['session'][-36:]).flatten().tolist()
-        else:
-            rec['id'] = d['url'][-36:]
-            rec['eid'] = d['session'][-36:]
+        rec['id'] = d['url'][-36:]
+        rec['eid'] = (d['session'] or '')[-36:]
         data_url = urllib.parse.urlsplit(file_record['data_url'], allow_fragments=False)
         file_path = get_alf_path(data_url.path.strip('/'))
-        file_path = alfio.remove_uuid_file(file_path, dry=True).as_posix()
-        rec['session_path'] = get_session_path(file_path).as_posix()
+        file_path = remove_uuid_string(file_path).as_posix()
+        rec['session_path'] = get_session_path(file_path) or ''
+        if rec['session_path']:
+            rec['session_path'] = rec['session_path'].as_posix()
         rec['rel_path'] = file_path[len(rec['session_path']):].strip('/')
         rec['default_revision'] = d['default_dataset']
+        for field in additional or []:
+            rec[field] = d.get(field)
         records.append(rec)
 
-    index = ['eid_0', 'eid_1', 'id_0', 'id_1'] if int_id else ['eid', 'id']
+    index = ['eid', 'id']
     if not records:
         keys = (*index, 'file_size', 'hash', 'session_path', 'rel_path', 'default_revision')
         return pd.DataFrame(columns=keys).set_index(index)
@@ -128,22 +119,22 @@ def datasets2records(datasets, int_id=False) -> pd.DataFrame:
 
 def parse_id(method):
     """
-    Ensures the input experiment identifier is an experiment UUID string
+    Ensures the input experiment identifier is an experiment UUID string.
 
     Parameters
     ----------
     method : function
-        An ONE method whose second arg is an experiment ID
+        An ONE method whose second arg is an experiment ID.
 
     Returns
     -------
     function
-        A wrapper function that parses the ID to the expected string
+        A wrapper function that parses the ID to the expected string.
 
     Raises
     ------
     ValueError
-        Unable to convert input to a valid experiment ID
+        Unable to convert input to a valid experiment ID.
     """
 
     @wraps(method)
@@ -158,7 +149,7 @@ def parse_id(method):
 
 def refresh(method):
     """
-    Refresh cache depending of query_type kwarg
+    Refresh cache depending of query_type kwarg.
     """
 
     @wraps(method)
@@ -174,7 +165,7 @@ def refresh(method):
 
 def validate_date_range(date_range) -> (pd.Timestamp, pd.Timestamp):
     """
-    Validates and arrange date range in a 2 elements list
+    Validates and arrange date range in a 2 elements list.
 
     Parameters
     ----------
@@ -184,7 +175,7 @@ def validate_date_range(date_range) -> (pd.Timestamp, pd.Timestamp):
     Returns
     -------
     tuple of pd.Timestamp
-        The start and end timestamps
+        The start and end timestamps.
 
     Examples
     --------
@@ -200,7 +191,7 @@ def validate_date_range(date_range) -> (pd.Timestamp, pd.Timestamp):
     Raises
     ------
     ValueError
-        Size of date range tuple must be 1 or 2
+        Size of date range tuple must be 1 or 2.
     """
     if date_range is None:
         return
@@ -239,14 +230,14 @@ def _collection_spec(collection=None, revision=None) -> str:
     Parameters
     ----------
     collection : None, str
-        An optional collection regular expression
+        An optional collection regular expression.
     revision : None, str
-        An optional revision regular expression
+        An optional revision regular expression.
 
     Returns
     -------
     str
-        A string format for matching the collection/revision
+        A string format for matching the collection/revision.
     """
     spec = ''
     for value, default in zip((collection, revision), ('{collection}/', '#{revision}#/')):
@@ -280,7 +271,7 @@ def _file_spec(**kwargs):
     Returns
     -------
     str
-        A string format for matching an ALF dataset
+        A string format for matching an ALF dataset.
     """
     OPTIONAL = {'namespace': '?', 'timescale': '?', 'extra': '*'}
     filespec = FILE_SPEC
@@ -411,17 +402,17 @@ def filter_revision_last_before(datasets, revision=None, assert_unique=True):
     Parameters
     ----------
     datasets : pandas.DataFrame
-        A datasets cache table
+        A datasets cache table.
     revision : str
-        A revision string to match (regular expressions not permitted)
+        A revision string to match (regular expressions not permitted).
     assert_unique : bool
         When true an alferr.ALFMultipleRevisionsFound exception is raised when multiple
-        default revisions are found; an alferr.ALFError when no default revision is found
+        default revisions are found; an alferr.ALFError when no default revision is found.
 
     Returns
     -------
     pd.DataFrame
-        A datasets DataFrame with 0 or 1 row per unique dataset
+        A datasets DataFrame with 0 or 1 row per unique dataset.
     """
     def _last_before(df):
         """Takes a DataFrame with only one dataset and multiple revisions, returns matching row"""
@@ -464,14 +455,14 @@ def index_last_before(revisions: List[str], revision: Optional[str]) -> Optional
     Parameters
     ----------
     revisions : list of strings
-        A list of revision strings
+        A list of revision strings.
     revision : None, str
-        The revision string to match on
+        The revision string to match on.
 
     Returns
     -------
     int, None
-        Index of revision before matching string in sorted list or None
+        Index of revision before matching string in sorted list or None.
 
     Examples
     --------
@@ -488,7 +479,7 @@ def index_last_before(revisions: List[str], revision: Optional[str]) -> Optional
 
 def autocomplete(term, search_terms) -> str:
     """
-    Validate search term and return complete name, e.g. autocomplete('subj') == 'subject'
+    Validate search term and return complete name, e.g. autocomplete('subj') == 'subject'.
     """
     term = term.lower()
     # Check if term already complete
@@ -504,7 +495,7 @@ def autocomplete(term, search_terms) -> str:
 
 
 def ensure_list(value):
-    """Ensure input is a list"""
+    """Ensure input is a list."""
     return [value] if isinstance(value, (str, dict)) or not isinstance(value, Iterable) else value
 
 
@@ -551,7 +542,7 @@ def cache_int2str(table: pd.DataFrame) -> pd.DataFrame:
     Parameters
     ----------
     table : pd.DataFrame
-        A cache table (from One._cache)
+        A cache table (from One._cache).
 
     """
     # Convert integer uuids to str uuids

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -31,7 +31,6 @@ Download a remote file, given a local path
 import json
 import logging
 import math
-import os
 import re
 import functools
 import urllib.request
@@ -354,22 +353,20 @@ def http_download_file(full_link_to_file, chunks=None, *, clobber=False, silent=
 
     # default cache directory is the home dir
     if not target_dir:
-        target_dir = str(Path.home().joinpath('Downloads'))
-
-    # This is the local file name
-    file_name = str(target_dir) + os.sep + os.path.basename(full_link_to_file)
-
-    # do not overwrite an existing file unless specified
-    if not clobber and os.path.exists(file_name):
-        return (file_name, hashfile.md5(file_name)) if return_md5 else file_name
+        target_dir = Path.home().joinpath('Downloads')
 
     # This should be the base url you wanted to access.
-    baseurl = os.path.split(str(full_link_to_file))[0]
+    base_url, name = full_link_to_file.rsplit('/', 1)
+    file_name = Path(target_dir, name)
+
+    # do not overwrite an existing file unless specified
+    if not clobber and file_name.exists():
+        return (file_name, hashfile.md5(file_name)) if return_md5 else file_name
 
     # Create a password manager
     manager = urllib.request.HTTPPasswordMgrWithDefaultRealm()
     if username and password:
-        manager.add_password(None, baseurl, username, password)
+        manager.add_password(None, base_url, username, password)
 
     # Create an authentication handler using the password manager
     auth = urllib.request.HTTPBasicAuthHandler(manager)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flake8>=3.7.8
 numpy>=1.18
-pandas>=1.2.4
+pandas>=1.5.0
 tqdm>=4.32.1
 requests>=2.22.0
 iblutil>=1.1.0


### PR DESCRIPTION
### Added

- OneAlyx.list_aggregates method to list datasets computed across more than one session
- OneAlyx.load_aggregate method to load dataset computed across more than one session
- one.alf.files.remove_uuid_string, complimenting add_uuid_string

### Modified

- removed support for integer UUIDs in cache tables
- support for pandas versions 1.5 - 2.0; dropped support for Python 3.7
- date field of session details a datetime.date object in remote mode (now consistent with local mode)
- support datasets table without session_path field
- clearer error message when cache directory not available
- support hyphens in collection part of ALF specification
- bugfix: safer construction of target directory from dataset URL in OneAlyx._download_dataset
- bugfix: mkdir called on destination instead of default location in AlyxClient.download_cache_tables
- support datasets table without session_path field
- clearer error message cache directory not available
- official support of relative path inputs for One.load_dataset(s)
- bugfix: one.webclient.http_download_file returns Path as documented, instead of str
- deprecated one.alf.io.remove_uuid_file and remove_uuid_recursive in favour of one.alf.files.remove_uuid_string
