### PR TITLE
Add check to see if dtype has a "shape" when checking object shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.8.0]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.8.1]
+
+### Modified
+
+- HOTFIX: fix error when sizing npz objects in alf.io.load_object
+
+## [2.8.0]
 This version of ONE adds support for loading .npz files.
 
 ### Modified

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API."""
-__version__ = '2.8.0'
+__version__ = '2.8.1'

--- a/one/alf/io.py
+++ b/one/alf/io.py
@@ -579,7 +579,10 @@ def load_object(alfpath, object=None, short_keys=False, **kwargs):
             # Expand timeseries if necessary
             out[key] = ts2vec(out[key], n_samples)
     if status != 0:
-        print_sizes = '\n'.join(f'{v.shape},\t{k}' for k, v in out.items())
+        supported = (np.ndarray, pd.DataFrame)
+        print_sizes = '\n'.join(
+            f'{v.shape},\t{k}' for k, v in out.items() if isinstance(v, supported)
+        )
         _logger.warning(f'Inconsistent dimensions for object: {object} \n{print_sizes}')
     return out
 


### PR DESCRIPTION
Currently in `load_object`, there is an attribute error when loading an `NpzFile` because this type does not have a `shape`. This adds the same check done in `check_dimensions` to the check done in `load_object`