### PR TITLE
V2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This version improves behaviour of loading revisions and loading datasets from l
 - warn user to reauthenticate when password is None in silent mode
 - always force authentication when password passed, even when token cached
 - bugfix: negative indexing of paginated response objects now functions correctly
+- deprecate one.util.ensure_list; moved to iblutil.util.ensure_list
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This version improves behaviour of loading revisions and loading datasets from l
 - sub-collections no longer captured when filtering with filename that starts with wildcard in wildcard mode
 - bugfix of spurious error raised when loading dataset with a revision provided
 - default_revisions_only parameter in One.list_datasets filters non-default datasets
+- permit data frame input to One.load_datasets and load precise relative paths provided (instead of default revisions)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This version improves behaviour of loading revisions and loading datasets from l
 - bugfix in one.params.setup: remove all extrenuous parameters (i.e. TOKEN) when running setup in silent mode
 - warn user to reauthenticate when password is None in silent mode
 - always force authentication when password passed, even when token cached
+- bugfix: negative indexing of paginated response objects now functions correctly
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.9.1]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.10.0]
+This version improves behaviour of loading revisions and loading datasets from list_datasets output. 
+
+### Modified
+
+- sub-collections no longer captured when filtering with filename that starts with wildcard in wildcard mode
+- bugfix of spurious error raised when loading dataset with a revision provided
+
+### Added
+
+- one.alf.exceptions.ALFWarning category allows users to filter warnings relating to mixed revisions
+
+## [2.9.1]
 
 ### Modified
 
@@ -7,7 +19,7 @@
 - HOTFIX: Ensure http data server URL does not end in slash
 - HOTFIX: Handle public aggregate dataset relative paths
 - HOTFIX: No longer warns in silent mode when no param conflicts present
-- Explicit kwargs in load_* methods to avoid user confusion (e.g. no 'namespace' kwarg for `load_dataset`)
+- explicit kwargs in load_* methods to avoid user confusion (e.g. no 'namespace' kwarg for `load_dataset`)
 
 ## [2.9.0]
 This version adds a couple of new ALF functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This version improves behaviour of loading revisions and loading datasets from l
 - default_revisions_only parameter in One.list_datasets filters non-default datasets
 - permit data frame input to One.load_datasets and load precise relative paths provided (instead of default revisions)
 - redundent session_path column has been dropped from the datasets cache table
+- bugfix in one.params.setup: suggest previous cache dir if available instead of always the default
+- bugfix in one.params.setup: remove all extrenuous parameters (i.e. TOKEN) when running setup in silent mode
+- warn user to reauthenticate when password is None in silent mode
+- always force authentication when password passed, even when token cached
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This version improves behaviour of loading revisions and loading datasets from l
 
 - sub-collections no longer captured when filtering with filename that starts with wildcard in wildcard mode
 - bugfix of spurious error raised when loading dataset with a revision provided
+- default_revisions_only parameter in One.list_datasets filters non-default datasets
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This version improves behaviour of loading revisions and loading datasets from l
 - bugfix of spurious error raised when loading dataset with a revision provided
 - default_revisions_only parameter in One.list_datasets filters non-default datasets
 - permit data frame input to One.load_datasets and load precise relative paths provided (instead of default revisions)
+- redundent session_path column has been dropped from the datasets cache table
 
 ### Added
 

--- a/docs/one_installation.md
+++ b/docs/one_installation.md
@@ -61,7 +61,7 @@ one = ONE()
 To change your default database, or re-run the setup for a given database, you can use the following
 
 ```python
-ONE._setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
+ONE.setup(base_url='https://test.alyx.internationalbrainlab.org', make_default=True)
 ```
 
 ## 4. Update

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API."""
-__version__ = '2.9.1'
+__version__ = '2.10.0'

--- a/one/alf/exceptions.py
+++ b/one/alf/exceptions.py
@@ -1,4 +1,4 @@
-"""ALyx File related errors.
+"""ALyx File related errors and warnings.
 
 A set of Alyx and ALF related error classes which provide a more verbose description of the raised
 issues.
@@ -82,3 +82,8 @@ class ALFMultipleRevisionsFound(ALFError):
     explanation = ('The matching object/file(s) belong to more than one revision.  '
                    'Multiple datasets in different revision folders were found with no default '
                    'specified.')
+
+
+class ALFWarning(Warning):
+    """Cautions when loading ALF datasets."""
+    pass

--- a/one/api.py
+++ b/one/api.py
@@ -131,7 +131,7 @@ class One(ConversionMixin):
 
             # Set the appropriate index if none already set
             if isinstance(cache.index, pd.RangeIndex):
-                idx_columns = cache.filter(regex=INDEX_KEY).columns.tolist()
+                idx_columns = sorted(cache.filter(regex=INDEX_KEY).columns)
                 if len(idx_columns) == 0:
                     raise KeyError('Failed to set index')
                 cache.set_index(idx_columns, inplace=True)
@@ -552,9 +552,8 @@ class One(ConversionMixin):
 
         Given a set of datasets, check whether records correctly reflect the filesystem.
         Called by load methods, this returns a list of file paths to load and return.
-        TODO This needs changing; overload for downloading?
-         This changes datasets frame, calls _update_cache(sessions=None, datasets=None) to
-         update and save tables.  Download_datasets can also call this function.
+        This changes datasets frame, calls _update_cache(sessions=None, datasets=None) to
+        update and save tables.  Download_datasets may also call this function.
 
         Parameters
         ----------
@@ -575,12 +574,18 @@ class One(ConversionMixin):
         """
         if isinstance(datasets, pd.Series):
             datasets = pd.DataFrame([datasets])
+            assert datasets.index.nlevels <= 2
+            idx_names = ['eid', 'id'] if datasets.index.nlevels == 2 else ['id']
+            datasets.index.set_names(idx_names, inplace=True)
         elif not isinstance(datasets, pd.DataFrame):
             # Cast set of dicts (i.e. from REST datasets endpoint)
             datasets = util.datasets2records(list(datasets))
+        else:
+            datasets = datasets.copy()
         indices_to_download = []  # indices of datasets that need (re)downloading
         files = []  # file path list to return
         # If the session_path field is missing from the datasets table, fetch from sessions table
+        # Typically only aggregate frames contain this column
         if 'session_path' not in datasets.columns:
             if 'eid' not in datasets.index.names:
                 # Get slice of full frame with eid in index
@@ -647,12 +652,12 @@ class One(ConversionMixin):
 
         if self.record_loaded:
             loaded = np.fromiter(map(bool, files), bool)
-            loaded_ids = np.array(datasets.index.to_list())[loaded]
+            loaded_ids = datasets.index.get_level_values('id')[loaded].to_numpy()
             if '_loaded_datasets' not in self._cache:
                 self._cache['_loaded_datasets'] = np.unique(loaded_ids)
             else:
                 loaded_set = np.hstack([self._cache['_loaded_datasets'], loaded_ids])
-                self._cache['_loaded_datasets'] = np.unique(loaded_set, axis=0)
+                self._cache['_loaded_datasets'] = np.unique(loaded_set)
 
         # Return full list of file paths
         return files
@@ -1013,6 +1018,9 @@ class One(ConversionMixin):
 
         # For those that don't exist, download them
         offline = None if query_type == 'auto' else self.mode == 'local'
+        if datasets.index.nlevels == 1:
+            # Reinstate eid index
+            datasets = pd.concat({str(eid): datasets}, names=['eid'])
         files = self._check_filesystem(datasets, offline=offline, check_hash=check_hash)
         files = [x for x in files if x]
         if not files:
@@ -1117,6 +1125,9 @@ class One(ConversionMixin):
                                         wildcards=self.wildcards, assert_unique=assert_unique)
         if len(datasets) == 0:
             raise alferr.ALFObjectNotFound(f'Dataset "{dataset}" not found')
+        if datasets.index.nlevels == 1:
+            # Reinstate eid index
+            datasets = pd.concat({str(eid): datasets}, names=['eid'])
 
         # Check files exist / download remote files
         offline = None if query_type == 'auto' else self.mode == 'local'
@@ -1288,6 +1299,9 @@ class One(ConversionMixin):
                   for x, y, z in zip(datasets, collections, revisions)]
         present = [len(x) == 1 for x in slices]
         present_datasets = pd.concat(slices)
+        if present_datasets.index.nlevels == 1:
+            # Reinstate eid index
+            present_datasets = pd.concat({str(eid): present_datasets}, names=['eid'])
 
         # Check if user is blindly downloading all data and warn of non-default revisions
         if 'default_revision' in present_datasets and \
@@ -1326,7 +1340,7 @@ class One(ConversionMixin):
 
         # Make list of metadata Bunches out of the table
         records = (present_datasets
-                   .reset_index(names='id')
+                   .reset_index(names=['eid', 'id'])
                    .to_dict('records', into=Bunch))
 
         # Ensure result same length as input datasets list
@@ -1459,6 +1473,9 @@ class One(ConversionMixin):
         if len(datasets) == 0:
             raise alferr.ALFObjectNotFound(object or '')
         parts = [alfiles.rel_path_parts(x) for x in datasets.rel_path]
+        if datasets.index.nlevels == 1:
+            # Reinstate eid index
+            datasets = pd.concat({str(eid): datasets}, names=['eid'])
 
         # For those that don't exist, download them
         offline = None if query_type == 'auto' else self.mode == 'local'
@@ -1868,8 +1885,7 @@ class OneAlyx(One):
         all_aggregates = self.alyx.rest('datasets', 'list', django=query)
         records = (util.datasets2records(all_aggregates)
                    .reset_index(level=0)
-                   .drop('eid', axis=1)
-                   .rename_axis(index={'id': 'did'}))
+                   .drop('eid', axis=1))
         # Since rel_path for public FI file records starts with 'public/aggregates' instead of just
         # 'aggregates', we should discard the file path parts before 'aggregates' (if present)
         records['rel_path'] = records['rel_path'].str.replace(
@@ -1890,11 +1906,6 @@ class OneAlyx(One):
             # NB: We avoid exact matches as most users will only include subject, not lab/subject
             records = records[records['identifier'].str.contains(identifier)]
 
-        # Add exists_aws field for download method
-        for i, rec in records.iterrows():
-            fr = next(x['file_records'] for x in all_aggregates if x['url'].endswith(i))
-            records.loc[i, 'exists_aws'] = any(
-                x['data_repository'].startswith('aws') and x['exists'] for x in fr)
         return util.filter_datasets(records, filename=dataset, revision=revision,
                                     wildcards=True, assert_unique=assert_unique)
 
@@ -1950,6 +1961,7 @@ class OneAlyx(One):
             raise alferr.ALFObjectNotFound(
                 f'{dataset or "dataset"} not found for {relation}/{identifier}')
         # update_exists=False because these datasets are not in the cache table
+        records['session_path'] = ''  # explicitly add session path column
         file, = self._check_filesystem(records, update_exists=False)
         if not file:
             raise alferr.ALFObjectNotFound('Dataset file not found on disk')
@@ -2286,9 +2298,12 @@ class OneAlyx(One):
         try:
             if not isinstance(dsets, pd.DataFrame):
                 raise TypeError('Input datasets must be a pandas data frame for AWS download.')
-            if 'exists_aws' in dsets and np.all(np.equal(dsets['exists_aws'].values, True)):
-                _logger.info('Downloading from AWS')
-                return self._download_aws(map(lambda x: x[1], dsets.iterrows()), **kwargs)
+            assert 'exists_aws' not in dsets or np.all(np.equal(dsets['exists_aws'].values, True))
+            _logger.debug('Downloading from AWS')
+            files = self._download_aws(map(lambda x: x[1], dsets.iterrows()), **kwargs)
+            # Trigger fallback download of any files missing on AWS
+            assert all(files), f'{sum(map(bool, files))} datasets not found on AWS'
+            return files
         except Exception as ex:
             _logger.debug(ex)
         return self._download_dataset(dsets, **kwargs)
@@ -2338,15 +2353,18 @@ class OneAlyx(One):
             # Fetch file record path
             record = next((x for x in record['file_records']
                            if x['data_repository'].startswith('aws') and x['exists']), None)
-            if not record and update_exists and 'exists_aws' in self._cache['datasets']:
-                _logger.debug('Updating exists field')
-                self._cache['datasets'].loc[(slice(None), uuid), 'exists_aws'] = False
-                self._cache['_meta']['modified_time'] = datetime.now()
+            if not record:
+                if update_exists and 'exists_aws' in self._cache['datasets']:
+                    _logger.debug('Updating exists field')
+                    self._cache['datasets'].loc[(slice(None), uuid), 'exists_aws'] = False
+                    self._cache['_meta']['modified_time'] = datetime.now()
                 out_files.append(None)
                 continue
+            assert record['relative_path'].endswith(dset['rel_path']), \
+                f'Relative path for dataset {uuid} does not match Alyx record'
             source_path = PurePosixPath(record['data_repository_path'], record['relative_path'])
             source_path = alfiles.add_uuid_string(source_path, uuid)
-            local_path = self.cache_dir.joinpath(dset['session_path'], dset['rel_path'])
+            local_path = self.cache_dir.joinpath(record['relative_path'])
             if keep_uuid is True or (keep_uuid is None and self.uuid_filenames is True):
                 local_path = alfiles.add_uuid_string(local_path, uuid)
             local_path.parent.mkdir(exist_ok=True, parents=True)

--- a/one/params.py
+++ b/one/params.py
@@ -158,7 +158,8 @@ def setup(client=None, silent=False, make_default=None, username=None, cache_dir
 
         # Prompt for cache directory (default may have changed after prompt)
         client_key = _key_from_url(par.ALYX_URL)
-        cache_dir = cache_dir or Path(CACHE_DIR_DEFAULT, client_key)
+        def_cache_dir = cache_map.CLIENT_MAP.get(client_key) or Path(CACHE_DIR_DEFAULT, client_key)
+        cache_dir = cache_dir or def_cache_dir
         prompt = f'Enter the location of the download cache, current value is ["{cache_dir}"]:'
         cache_dir = input(prompt) or cache_dir
 
@@ -185,7 +186,9 @@ def setup(client=None, silent=False, make_default=None, username=None, cache_dir
         # Precedence: user provided cache_dir; previously defined; the default location
         default_cache_dir = Path(CACHE_DIR_DEFAULT, client_key)
         cache_dir = cache_dir or cache_map.CLIENT_MAP.get(client_key, default_cache_dir)
-        par = par_current
+        # Use current params but drop any extras (such as the TOKEN or ALYX_PWD field)
+        keep_keys = par_default.as_dict().keys()
+        par = iopar.from_dict({k: v for k, v in par_current.as_dict().items() if k in keep_keys})
         if any(v for k, v in cache_map.CLIENT_MAP.items() if k != client_key and v == cache_dir):
             warnings.warn('Warning: the directory provided is already a cache for another URL.')
 

--- a/one/registration.py
+++ b/one/registration.py
@@ -23,14 +23,13 @@ import shutil
 import requests.exceptions
 
 from iblutil.io import hashfile
-from iblutil.util import Bunch
+from iblutil.util import Bunch, ensure_list
 
 import one.alf.io as alfio
 from one.alf.files import session_path_parts, get_session_path, folder_parts, filename_parts
 from one.alf.spec import is_valid
 import one.alf.exceptions as alferr
 from one.api import ONE
-from one.util import ensure_list
 from one.webclient import no_cache
 
 _logger = logging.getLogger(__name__)

--- a/one/remote/globus.py
+++ b/one/remote/globus.py
@@ -97,12 +97,12 @@ import globus_sdk
 from globus_sdk import TransferAPIError, GlobusAPIError, NetworkError, GlobusTimeoutError, \
     GlobusConnectionError, GlobusConnectionTimeoutError, GlobusSDKUsageError, NullAuthorizer
 from iblutil.io import params as iopar
+from iblutil.util import ensure_list
 
 from one.alf.spec import is_uuid
 from one.alf.files import remove_uuid_string
 import one.params
 from one.webclient import AlyxClient
-from one.util import ensure_list
 from .base import DownloadClient, load_client_params, save_client_params
 
 __all__ = ['Globus', 'get_lab_from_endpoint_id', 'as_globus_path']

--- a/one/tests/alf/test_alf_io.py
+++ b/one/tests/alf/test_alf_io.py
@@ -727,7 +727,7 @@ class TestFindVariants(unittest.TestCase):
             self.session_path.joinpath(f'bar.baz_y.{uuid.uuid4()}.npy'),
             self.session_path.joinpath('#2021-01-01#', f'bar.baz.{uuid.uuid4()}.npy'),
             self.session_path.joinpath('task_00', 'x.y.z'),
-            self.session_path.joinpath('x.y.z'),
+            self.session_path.joinpath('x.y.z')
         ]
         for f in self.dsets:
             f.parent.mkdir(exist_ok=True, parents=True)

--- a/one/tests/alf/test_cache.py
+++ b/one/tests/alf/test_cache.py
@@ -81,7 +81,6 @@ class TestsONEParquet(unittest.TestCase):
         print('Datasets dataframe')
         print(df)
         dset_info = df.loc[0].to_dict()
-        self.assertEqual(dset_info['session_path'], self.rel_ses_path[:-1])
         self.assertEqual(dset_info['rel_path'], self.rel_ses_files[0].as_posix())
         self.assertTrue(dset_info['file_size'] > 0)
         self.assertFalse(df.rel_path.str.contains('invalid').any())
@@ -100,7 +99,6 @@ class TestsONEParquet(unittest.TestCase):
         df_dsets, metadata2 = parquet.load(fn_dsets)
         self.assertEqual(metadata2, metadata_exp)
         dset_info = df_dsets.loc[0].to_dict()
-        self.assertEqual(dset_info['session_path'], self.rel_ses_path[:-1])
         self.assertEqual(dset_info['rel_path'], self.rel_ses_files[0].as_posix())
 
         # Check behaviour when no files found
@@ -115,12 +113,9 @@ class TestsONEParquet(unittest.TestCase):
             apt.make_parquet_db(self.tmpdir, hash_ids=False, lab='another')
 
         # Create some more datasets in a session folder outside of a lab directory
-        dsets = revisions_datasets_table()
         with tempfile.TemporaryDirectory() as tdir:
-            for session_path, rel_path in dsets[['session_path', 'rel_path']].values:
-                filepath = Path(tdir).joinpath(session_path, rel_path)
-                filepath.parent.mkdir(exist_ok=True, parents=True)
-                filepath.touch()
+            session_path = Path(tdir).joinpath('subject', '1900-01-01', '001')
+            _ = revisions_datasets_table(touch_path=session_path)  # create some files
             fn_ses, _ = apt.make_parquet_db(tdir, hash_ids=False, lab='another')
             df_ses, _ = parquet.load(fn_ses)
             self.assertTrue((df_ses['lab'] == 'another').all())

--- a/one/tests/remote/test_globus.py
+++ b/one/tests/remote/test_globus.py
@@ -107,7 +107,7 @@ class TestGlobus(unittest.TestCase):
         # Only test this on windows
         if sys.platform == 'win32':
             actual = globus.as_globus_path('/foo/bar')
-            self.assertEqual(actual, f'/{Path.cwd().drive[0]}/foo/bar')
+            self.assertEqual(actual, f'/{Path.cwd().drive[0].upper()}/foo/bar')
 
         # On all systems an explicit Windows path should be converted to a POSIX one
         actual = globus.as_globus_path(PureWindowsPath('E:\\FlatIron\\integration'))

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -116,7 +116,8 @@ def setup_test_params(token=False, cache_dir=None):
 def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
                              revisions=('', '2020-01-08', '2021-07-06'),
                              object='spikes',
-                             attributes=('times', 'waveforems')):
+                             attributes=('times', 'waveforems'),
+                             touch_path=None):
     """Returns a datasets cache DataFrame containing datasets with revision folders.
 
     As there are no revised datasets on the test databases, this function acts as a fixture for
@@ -132,6 +133,8 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
         An ALF object
     attributes : tuple
         A list of ALF attributes
+    touch_path : pathlib.Path, str
+        If provided, files are created in this directory.
 
     Returns
     -------
@@ -154,6 +157,12 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
         'eid': str(uuid4()),
         'id': map(str, (uuid4() for _ in rel_path))
     }
+
+    if touch_path:
+        for p in rel_path:
+            path = Path(touch_path).joinpath(d['session_path'] + '/' + p)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
 
     return pd.DataFrame(data=d).astype({'qc': QC_TYPE}).set_index(['eid', 'id'])
 

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -11,6 +11,7 @@ from iblutil.io.params import set_hidden
 
 import one.params
 from one.util import QC_TYPE
+from one.converters import session_record2path
 
 
 def set_up_env() -> tempfile.TemporaryDirectory:
@@ -68,7 +69,8 @@ def create_file_tree(one):
 
     """
     # Create dset files from cache
-    for session_path, rel_path in one._cache.datasets[['session_path', 'rel_path']].values:
+    for (eid, _), rel_path in one._cache.datasets['rel_path'].items():
+        session_path = session_record2path(one._cache.sessions.loc[eid])
         filepath = Path(one.cache_dir).joinpath(session_path, rel_path)
         filepath.parent.mkdir(exist_ok=True, parents=True)
         filepath.touch()
@@ -139,7 +141,7 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
     Returns
     -------
     pd.DataFrame
-        A datasets cache table containing datasets made from the input names
+        A datasets cache table containing datasets made from the input names.
 
     """
     rel_path = []
@@ -149,7 +151,6 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
                 rel_path.append('/'.join(x for x in (collec, rev, f'{object}.{attr}.npy') if x))
     d = {
         'rel_path': rel_path,
-        'session_path': 'subject/1900-01-01/001',
         'file_size': 0,
         'hash': None,
         'exists': True,
@@ -160,7 +161,7 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
 
     if touch_path:
         for p in rel_path:
-            path = Path(touch_path).joinpath(d['session_path'] + '/' + p)
+            path = Path(touch_path).joinpath(p)
             path.parent.mkdir(parents=True, exist_ok=True)
             path.touch()
 

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -147,7 +147,7 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
     d = {
         'rel_path': rel_path,
         'session_path': 'subject/1900-01-01/001',
-        'file_size': None,
+        'file_size': 0,
         'hash': None,
         'exists': True,
         'qc': 'NOT_SET',

--- a/one/util.py
+++ b/one/util.py
@@ -60,8 +60,8 @@ def ses2records(ses: dict):
         rec['eid'] = session.name
         file_path = urllib.parse.urlsplit(d['data_url'], allow_fragments=False).path.strip('/')
         file_path = get_alf_path(remove_uuid_string(file_path))
-        rec['session_path'] = get_session_path(file_path).as_posix()
-        rec['rel_path'] = file_path[len(rec['session_path']):].strip('/')
+        session_path = get_session_path(file_path).as_posix()
+        rec['rel_path'] = file_path[len(session_path):].strip('/')
         rec['default_revision'] = d['default_revision'] == 'True'
         rec['qc'] = d.get('qc', 'NOT_SET')
         return rec
@@ -106,10 +106,10 @@ def datasets2records(datasets, additional=None) -> pd.DataFrame:
         data_url = urllib.parse.urlsplit(file_record['data_url'], allow_fragments=False)
         file_path = get_alf_path(data_url.path.strip('/'))
         file_path = remove_uuid_string(file_path).as_posix()
-        rec['session_path'] = get_session_path(file_path) or ''
-        if rec['session_path']:
-            rec['session_path'] = rec['session_path'].as_posix()
-        rec['rel_path'] = file_path[len(rec['session_path']):].strip('/')
+        session_path = get_session_path(file_path) or ''
+        if session_path:
+            session_path = session_path.as_posix()
+        rec['rel_path'] = file_path[len(session_path):].strip('/')
         rec['default_revision'] = d['default_dataset']
         rec['qc'] = d.get('qc')
         for field in additional or []:
@@ -677,4 +677,6 @@ def patch_cache(table: pd.DataFrame, min_api_version=None, name=None) -> pd.Data
     if name == 'datasets' and min_version < version.Version('2.7.0') and 'qc' not in table.columns:
         qc = pd.Categorical.from_codes(np.zeros(len(table.index), dtype=int), dtype=QC_TYPE)
         table = table.assign(qc=qc)
+    if name == 'datasets' and 'session_path' in table.columns:
+        table = table.drop('session_path', axis=1)
     return table

--- a/one/util.py
+++ b/one/util.py
@@ -445,7 +445,11 @@ def filter_datasets(
             else:
                 return match
 
-    return filter_revision_last_before(match, revision, assert_unique=assert_unique)
+    match = filter_revision_last_before(match, revision, assert_unique=assert_unique)
+    if assert_unique and len(match) > 1:
+        _list = '"' + '", "'.join(match['rel_path']) + '"'
+        raise alferr.ALFMultipleObjectsFound(_list)
+    return match
 
 
 def filter_revision_last_before(

--- a/one/util.py
+++ b/one/util.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 import pandas as pd
 from iblutil.io import parquet
+from iblutil.util import ensure_list as _ensure_list
 import numpy as np
 from packaging import version
 
@@ -96,7 +97,7 @@ def datasets2records(datasets, additional=None) -> pd.DataFrame:
     """
     records = []
 
-    for d in ensure_list(datasets):
+    for d in _ensure_list(datasets):
         file_record = next((x for x in d['file_records'] if x['data_url'] and x['exists']), None)
         if not file_record:
             continue  # Ignore files that are not accessible
@@ -396,7 +397,7 @@ def filter_datasets(
         exclude_slash = partial(re.sub, fr'^({flagless_token})?\.\*', r'\g<1>[^/]*')
         spec_str += '|'.join(
             exclude_slash(fnmatch.translate(x)) if wildcards else x + '$'
-            for x in ensure_list(filename)
+            for x in _ensure_list(filename)
         )
 
     # If matching revision name, add to regex string
@@ -408,7 +409,7 @@ def filter_datasets(
             continue
         if wildcards:
             # Convert to regex, remove \\Z which asserts end of string
-            v = (fnmatch.translate(x).replace('\\Z', '') for x in ensure_list(v))
+            v = (fnmatch.translate(x).replace('\\Z', '') for x in _ensure_list(v))
         if not isinstance(v, str):
             regex_args[k] = '|'.join(v)  # logical OR
 
@@ -592,7 +593,10 @@ def autocomplete(term, search_terms) -> str:
 
 def ensure_list(value):
     """Ensure input is a list."""
-    return [value] if isinstance(value, (str, dict)) or not isinstance(value, Iterable) else value
+    warnings.warn(
+        'one.util.ensure_list is deprecated, use iblutil.util.ensure_list instead',
+        DeprecationWarning)
+    return _ensure_list(value)
 
 
 class LazyId(Mapping):

--- a/one/util.py
+++ b/one/util.py
@@ -392,8 +392,8 @@ def filter_datasets(
         # Convert to regex if necessary and assert end of string
         flagless_token = re.escape(r'(?s:')  # fnmatch.translate may wrap input in flagless group
         # If there is a wildcard at the start of the filename we must exclude capture of slashes to
-        # avoid capture of collection part, e.g. * -> .* -> [^/]+ (one or more non-slash chars)
-        exclude_slash = partial(re.sub, fr'^({flagless_token})?\.[*?]', r'\g<1>[^/]+')
+        # avoid capture of collection part, e.g. * -> .* -> [^/]* (one or more non-slash chars)
+        exclude_slash = partial(re.sub, fr'^({flagless_token})?\.\*', r'\g<1>[^/]*')
         spec_str += '|'.join(
             exclude_slash(fnmatch.translate(x)) if wildcards else x + '$'
             for x in ensure_list(filename)

--- a/one/util.py
+++ b/one/util.py
@@ -1,10 +1,12 @@
 """Decorators and small standalone functions for api module."""
+import re
 import logging
 import urllib.parse
-from functools import wraps
+import fnmatch
+import warnings
+from functools import wraps, partial
 from typing import Sequence, Union, Iterable, Optional, List
 from collections.abc import Mapping
-import fnmatch
 from datetime import datetime
 
 import pandas as pd
@@ -307,7 +309,9 @@ def filter_datasets(
     revision_last_before : bool
         When true and no exact match exists, the (lexicographically) previous revision is used
         instead.  When false the revision string is matched like collection and filename,
-        with regular expressions permitted.
+        with regular expressions permitted.  NB: When true and `revision` is None the default
+        revision is returned which may not be the last revision. If no default is defined, the
+        last revision is returned.
     qc : str, int, one.alf.spec.QC
         Returns datasets at or below this QC level.  Integer values should correspond to the QC
         enumeration NOT the qc category column codes in the pandas table.
@@ -350,6 +354,26 @@ def filter_datasets(
 
     >>> datasets filter_datasets(all_datasets, qc='PASS', ignore_qc_not_set=True)
 
+    Raises
+    ------
+    one.alf.exceptions.ALFMultipleCollectionsFound
+        The matching list of datasets have more than one unique collection and `assert_unique` is
+        True.
+    one.alf.exceptions.ALFMultipleRevisionsFound
+        When `revision_last_before` is false, the matching list of datasets have more than one
+        unique revision.  When `revision_last_before` is true, a 'default_revision' column exists,
+        and no revision is passed, this error means that one or more matching datasets have
+        multiple revisions specified as the default. This is typically an error in the cache table
+        itself as all datasets should have one and only one default revision specified.
+    one.alf.exceptions.ALFMultipleObjectsFound
+        The matching list of datasets have more than one unique filename and both `assert_unique`
+        and `revision_last_before` are true.
+    one.alf.exceptions.ALFError
+        When both `assert_unique` and `revision_last_before` is true, and a 'default_revision'
+        column exists but `revision` is None; one or more matching datasets have no default
+        revision specified. This is typically an error in the cache table itself as all datasets
+        should have one and only one default revision specified.
+
     Notes
     -----
     - It is not possible to match datasets that are in a given collection OR NOT in ANY collection.
@@ -365,9 +389,15 @@ def filter_datasets(
         spec_str += _file_spec(**filename)
         regex_args.update(**filename)
     else:
-        # Convert to regex is necessary and assert end of string
-        filename = [fnmatch.translate(x) if wildcards else x + '$' for x in ensure_list(filename)]
-        spec_str += '|'.join(filename)
+        # Convert to regex if necessary and assert end of string
+        flagless_token = re.escape(r'(?s:')  # fnmatch.translate may wrap input in flagless group
+        # If there is a wildcard at the start of the filename we must exclude capture of slashes to
+        # avoid capture of collection part, e.g. * -> .* -> [^/]+ (one or more non-slash chars)
+        exclude_slash = partial(re.sub, fr'^({flagless_token})?\.[*?]', r'\g<1>[^/]+')
+        spec_str += '|'.join(
+            exclude_slash(fnmatch.translate(x)) if wildcards else x + '$'
+            for x in ensure_list(filename)
+        )
 
     # If matching revision name, add to regex string
     if not revision_last_before:
@@ -393,33 +423,33 @@ def filter_datasets(
         qc_match &= all_datasets['qc'].ne('NOT_SET')
 
     # Filter datasets on path and QC
-    match = all_datasets[path_match & qc_match]
+    match = all_datasets[path_match & qc_match].copy()
     if len(match) == 0 or not (revision_last_before or assert_unique):
         return match
 
-    revisions = [rel_path_parts(x)[1] or '' for x in match.rel_path.values]
+    # Extract revision to separate column
+    if 'revision' not in match.columns:
+        match['revision'] = match.rel_path.map(lambda x: rel_path_parts(x)[1] or '')
     if assert_unique:
         collections = set(rel_path_parts(x)[0] or '' for x in match.rel_path.values)
         if len(collections) > 1:
             _list = '"' + '", "'.join(collections) + '"'
             raise alferr.ALFMultipleCollectionsFound(_list)
         if not revision_last_before:
-            if filename and len(match) > 1:
+            if len(set(match['revision'])) > 1:
+                _list = '"' + '", "'.join(set(match['revision'])) + '"'
+                raise alferr.ALFMultipleRevisionsFound(_list)
+            if len(match) > 1:
                 _list = '"' + '", "'.join(match['rel_path']) + '"'
                 raise alferr.ALFMultipleObjectsFound(_list)
-            if len(set(revisions)) > 1:
-                _list = '"' + '", "'.join(set(revisions)) + '"'
-                raise alferr.ALFMultipleRevisionsFound(_list)
             else:
                 return match
-        elif filename and len(set(revisions)) != len(revisions):
-            _list = '"' + '", "'.join(match['rel_path']) + '"'
-            raise alferr.ALFMultipleObjectsFound(_list)
 
     return filter_revision_last_before(match, revision, assert_unique=assert_unique)
 
 
-def filter_revision_last_before(datasets, revision=None, assert_unique=True):
+def filter_revision_last_before(
+        datasets, revision=None, assert_unique=True, assert_consistent=False):
     """
     Filter datasets by revision, returning previous revision in ordered list if revision
     doesn't exactly match.
@@ -433,43 +463,80 @@ def filter_revision_last_before(datasets, revision=None, assert_unique=True):
     assert_unique : bool
         When true an alferr.ALFMultipleRevisionsFound exception is raised when multiple
         default revisions are found; an alferr.ALFError when no default revision is found.
+    assert_consistent : bool
+        Will raise alferr.ALFMultipleRevisionsFound if matching revision is different between
+        datasets.
 
     Returns
     -------
     pd.DataFrame
         A datasets DataFrame with 0 or 1 row per unique dataset.
+
+    Raises
+    ------
+    one.alf.exceptions.ALFMultipleRevisionsFound
+        When the 'default_revision' column exists and no revision is passed, this error means that
+        one or more matching datasets have multiple revisions specified as the default. This is
+        typically an error in the cache table itself as all datasets should have one and only one
+        default revision specified.
+        When `assert_consistent` is True, this error may mean that the matching datasets have
+        mixed revisions.
+    one.alf.exceptions.ALFMultipleObjectsFound
+        The matching list of datasets have more than one unique filename and both `assert_unique`
+        and `revision_last_before` are true.
+    one.alf.exceptions.ALFError
+        When both `assert_unique` and `revision_last_before` is true, and a 'default_revision'
+        column exists but `revision` is None; one or more matching datasets have no default
+        revision specified. This is typically an error in the cache table itself as all datasets
+        should have one and only one default revision specified.
+
+    Notes
+    -----
+    - When `revision` is not None, the default revision value is not used. If an older revision is
+      the default one (uncommon), passing in a revision may lead to a newer revision being returned
+      than if revision is None.
+    - A view is returned if a revision column is present, otherwise a copy is returned.
     """
     def _last_before(df):
         """Takes a DataFrame with only one dataset and multiple revisions, returns matching row"""
-        if revision is None and 'default_revision' in df.columns:
-            if assert_unique and sum(df.default_revision) > 1:
-                revisions = df['revision'][df.default_revision.values]
-                rev_list = '"' + '", "'.join(revisions) + '"'
-                raise alferr.ALFMultipleRevisionsFound(rev_list)
-            if sum(df.default_revision) == 1:
-                return df[df.default_revision]
-            if len(df) == 1:  # This may be the case when called from load_datasets
-                return df  # It's not the default be there's only one available revision
-            # default_revision column all False; default isn't copied to remote repository
+        if revision is None:
             dset_name = df['rel_path'].iloc[0]
-            if assert_unique:
-                raise alferr.ALFError(f'No default revision for dataset {dset_name}')
-            else:
-                logger.warning(f'No default revision for dataset {dset_name}; using most recent')
+            if 'default_revision' in df.columns:
+                if assert_unique and sum(df.default_revision) > 1:
+                    revisions = df['revision'][df.default_revision.values]
+                    rev_list = '"' + '", "'.join(revisions) + '"'
+                    raise alferr.ALFMultipleRevisionsFound(rev_list)
+                if sum(df.default_revision) == 1:
+                    return df[df.default_revision]
+                if len(df) == 1:  # This may be the case when called from load_datasets
+                    return df  # It's not the default but there's only one available revision
+                # default_revision column all False; default isn't copied to remote repository
+                if assert_unique:
+                    raise alferr.ALFError(f'No default revision for dataset {dset_name}')
+            warnings.warn(
+                f'No default revision for dataset {dset_name}; using most recent',
+                alferr.ALFWarning)
         # Compare revisions lexicographically
-        if assert_unique and len(df['revision'].unique()) > 1:
-            rev_list = '"' + '", "'.join(df['revision'].unique()) + '"'
-            raise alferr.ALFMultipleRevisionsFound(rev_list)
-        # Square brackets forces 1 row DataFrame returned instead of Series
         idx = index_last_before(df['revision'].tolist(), revision)
-        # return df.iloc[slice(0, 0) if idx is None else [idx], :]
+        # Square brackets forces 1 row DataFrame returned instead of Series
         return df.iloc[slice(0, 0) if idx is None else [idx], :]
 
-    with pd.option_context('mode.chained_assignment', None):  # FIXME Explicitly copy?
-        datasets['revision'] = [rel_path_parts(x)[1] or '' for x in datasets.rel_path]
+    # Extract revision to separate column
+    if 'revision' not in datasets.columns:
+        with pd.option_context('mode.chained_assignment', None):  # FIXME Explicitly copy?
+            datasets['revision'] = datasets.rel_path.map(lambda x: rel_path_parts(x)[1] or '')
+    # Group by relative path (sans revision)
     groups = datasets.rel_path.str.replace('#.*#/', '', regex=True).values
     grouped = datasets.groupby(groups, group_keys=False)
-    return grouped.apply(_last_before)
+    filtered = grouped.apply(_last_before)
+    # Raise if matching revision is different between datasets
+    if len(filtered['revision'].unique()) > 1:
+        rev_list = '"' + '", "'.join(filtered['revision'].unique()) + '"'
+        if assert_consistent:
+            raise alferr.ALFMultipleRevisionsFound(rev_list)
+        else:
+            warnings.warn(f'Multiple revisions: {rev_list}', alferr.ALFWarning)
+    return filtered
 
 
 def index_last_before(revisions: List[str], revision: Optional[str]) -> Optional[int]:

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -54,7 +54,7 @@ from pprint import pprint
 import one.params
 from iblutil.io import hashfile
 from iblutil.io.params import set_hidden
-from one.util import ensure_list
+from iblutil.util import ensure_list
 import concurrent.futures
 _logger = logging.getLogger(__name__)
 

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -213,9 +213,12 @@ class _PaginatedResponse(Mapping):
     def __getitem__(self, item):
         if isinstance(item, slice):
             while None in self._cache[item]:
-                self.populate(item.start + self._cache[item].index(None))
+                # If slice start index is -ve, convert to +ve index
+                i = self.count + item.start if item.start < 0 else item.start
+                self.populate(i + self._cache[item].index(None))
         elif self._cache[item] is None:
-            self.populate(item)
+            # If index is -ve, convert to +ve
+            self.populate(self.count + item if item < 0 else item)
         return self._cache[item]
 
     def populate(self, idx):

--- a/one/webclient.py
+++ b/one/webclient.py
@@ -642,6 +642,11 @@ class AlyxClient:
         if username is None and not self.silent:
             username = input('Enter Alyx username:')
 
+        # If user passes in a password, force re-authentication even if token cached
+        if password is not None:
+            if not force:
+                _logger.debug('Forcing token request with provided password')
+            force = True
         # Check if token cached
         if not force and getattr(self._par, 'TOKEN', False) and username in self._par.TOKEN:
             self._token = self._par.TOKEN[username]
@@ -654,8 +659,17 @@ class AlyxClient:
         # Get password
         if password is None:
             password = getattr(self._par, 'ALYX_PWD', None)
-        if password is None and not self.silent:
-            password = getpass(f'Enter Alyx password for "{username}":')
+        if password is None:
+            if self.silent:
+                warnings.warn(
+                    'No password or cached token in silent mode. '
+                    'Please run the following to re-authenticate:\n\t'
+                    'AlyxClient(silent=False).authenticate'
+                    '(username=<username>, force=True)', UserWarning)
+            else:
+                password = getpass(f'Enter Alyx password for "{username}":')
+        # Remove previous token
+        self._clear_token(username)
         try:
             credentials = {'username': username, 'password': password}
             rep = requests.post(self.base_url + '/auth-token', data=credentials)
@@ -692,14 +706,12 @@ class AlyxClient:
         if not self.silent:
             print(f'Connected to {self.base_url} as user "{self.user}"')
 
-    def logout(self):
-        """Log out from Alyx.
-        Deletes the cached authentication token for the currently logged-in user.
+    def _clear_token(self, username):
+        """Remove auth token from client params.
+
+        Deletes the cached authentication token for a given user.
         """
-        if not self.is_logged_in:
-            return
         par = one.params.get(client=self.base_url, silent=True)
-        username = self.user
         # Remove token from cache
         if getattr(par, 'TOKEN', False) and username in par.TOKEN:
             del par.TOKEN[username]
@@ -708,10 +720,20 @@ class AlyxClient:
         if getattr(self._par, 'TOKEN', False) and username in self._par.TOKEN:
             del self._par.TOKEN[username]
         # Remove token from object
-        self.user = None
         self._token = None
         if self._headers and 'Authorization' in self._headers:
             del self._headers['Authorization']
+
+    def logout(self):
+        """Log out from Alyx.
+
+        Deletes the cached authentication token for the currently logged-in user
+        and clears the REST cache.
+        """
+        if not self.is_logged_in:
+            return
+        self._clear_token(username := self.user)
+        self.user = None
         self.clear_rest_cache()
         if not self.silent:
             print(f'{username} logged out from {self.base_url}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.18
 pandas>=1.5.0
 tqdm>=4.32.1
 requests>=2.22.0
-iblutil>=1.1.0
+iblutil>=1.13.0
 packaging
 boto3
 pyyaml


### PR DESCRIPTION
This version improves behaviour of loading revisions and loading datasets from list_datasets output. 

### Modified

- sub-collections no longer captured when filtering with filename that starts with wildcard in wildcard mode
- bugfix of spurious error raised when loading dataset with a revision provided
- default_revisions_only parameter in One.list_datasets filters non-default datasets
- permit data frame input to One.load_datasets and load precise relative paths provided (instead of default revisions)
- redundent session_path column has been dropped from the datasets cache table
- bugfix in one.params.setup: suggest previous cache dir if available instead of always the default
- bugfix in one.params.setup: remove all extrenuous parameters (i.e. TOKEN) when running setup in silent mode
- warn user to reauthenticate when password is None in silent mode
- always force authentication when password passed, even when token cached
- bugfix: negative indexing of paginated response objects now functions correctly

### Added

- one.alf.exceptions.ALFWarning category allows users to filter warnings relating to mixed revisions