### PR TITLE
Refactor function locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This version fixes issues with Alyx authentication in silent mode, and improves 
 - always force authentication when password passed, even when token cached
 - bugfix: negative indexing of paginated response objects now functions correctly
 - deprecate one.util.ensure_list; moved to iblutil.util.ensure_list
+- OneAlyx uses remote mode by default, instead of auto
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ This version drops support for python 3.9 and below, and ONE is now in remote mo
 - supports python >= 3.10 only
 - OneAlyx uses remote mode by default, instead of auto
 - OneAlyx.search now updates the cache tables in remote mode as paginated sessions are accessed
+- Datasets table file_size column nullable by default
 
 ### Added
 
 - one.alf.cache.remove_cache_table_files and One.\_remove_cache_table_files for deleting cache table files
+- one.alf.cache.EMPTY_DATASETS_FRAME and EMPTY_SESSION_FRAME vars for table column, index, and dtype template
 
 ## [2.11.0]
 This version deprecates one.alf.files in preperation for replacing with one.alf.path in version 3.

--- a/one/api.py
+++ b/one/api.py
@@ -21,7 +21,7 @@ import requests.exceptions
 import packaging.version
 
 from iblutil.io import parquet, hashfile
-from iblutil.util import Bunch, flatten, ensure_list
+from iblutil.util import Bunch, flatten, ensure_list, Listable
 
 import one.params
 import one.webclient as wc
@@ -29,10 +29,12 @@ import one.alf.io as alfio
 import one.alf.path as alfiles
 import one.alf.exceptions as alferr
 from .alf.cache import (
-    make_parquet_db, remove_cache_table_files, DATASETS_COLUMNS, SESSIONS_COLUMNS)
+    make_parquet_db, patch_cache, remove_cache_table_files,
+    EMPTY_DATASETS_FRAME, EMPTY_SESSIONS_FRAME
+)
 from .alf.spec import is_uuid_string, QC, to_alf
 from . import __version__
-from one.converters import ConversionMixin, session_record2path
+from one.converters import ConversionMixin, session_record2path, ses2records, datasets2records
 from one import util
 
 _logger = logging.getLogger(__name__)
@@ -101,8 +103,8 @@ class One(ConversionMixin):
     def _reset_cache(self):
         """Replace the cache object with a Bunch that contains the right fields."""
         self._cache = Bunch({
-            'datasets': pd.DataFrame(columns=DATASETS_COLUMNS).set_index(['eid', 'id']),
-            'sessions': pd.DataFrame(columns=SESSIONS_COLUMNS).set_index('id'),
+            'datasets': EMPTY_DATASETS_FRAME.copy(),
+            'sessions': EMPTY_SESSIONS_FRAME.copy(),
             '_meta': {
                 'expired': False,
                 'created_time': None,
@@ -160,7 +162,7 @@ class One(ConversionMixin):
                 cache.set_index(idx_columns, inplace=True)
 
             # Patch older tables
-            cache = util.patch_cache(cache, meta['raw'][table].get('min_api_version'), table)
+            cache = patch_cache(cache, meta['raw'][table].get('min_api_version'), table)
 
             # Check sorted
             # Sorting makes MultiIndex indexing O(N) -> O(1)
@@ -173,6 +175,9 @@ class One(ConversionMixin):
             # No tables present
             meta['expired'] = True
             meta['raw'] = {}
+            self._cache.update({
+                'datasets': EMPTY_DATASETS_FRAME.copy(),
+                'sessions': EMPTY_SESSIONS_FRAME.copy()})
             if self.offline:  # In online mode, the cache tables should be downloaded later
                 warnings.warn(f'No cache tables found in {self._tables_dir}')
         created = [datetime.fromisoformat(x['date_created'])
@@ -286,7 +291,7 @@ class One(ConversionMixin):
 
         Example
         -------
-        >>> session, datasets = util.ses2records(self.get_details(eid, full=True))
+        >>> session, datasets = ses2records(self.get_details(eid, full=True))
         ... self._update_cache_from_records(sessions=session, datasets=datasets)
 
         Raises
@@ -599,7 +604,7 @@ class One(ConversionMixin):
             datasets.index.set_names(idx_names, inplace=True)
         elif not isinstance(datasets, pd.DataFrame):
             # Cast set of dicts (i.e. from REST datasets endpoint)
-            datasets = util.datasets2records(list(datasets))
+            datasets = datasets2records(list(datasets))
         else:
             datasets = datasets.copy()
         indices_to_download = []  # indices of datasets that need (re)downloading
@@ -1868,7 +1873,7 @@ class OneAlyx(One):
         eid = self.to_eid(eid)  # Ensure we have a UUID str list
         if not eid:
             return self._cache['datasets'].iloc[0:0] if details else []  # Return empty
-        session, datasets = util.ses2records(self.alyx.rest('sessions', 'read', id=eid))
+        session, datasets = ses2records(self.alyx.rest('sessions', 'read', id=eid))
         # Add to cache tables
         self._update_cache_from_records(sessions=session, datasets=datasets.copy())
         if datasets is None or datasets.empty:
@@ -1913,7 +1918,7 @@ class OneAlyx(One):
         """
         query = 'session__isnull,True'  # ',data_repository_name__endswith,aggregates'
         all_aggregates = self.alyx.rest('datasets', 'list', django=query)
-        records = (util.datasets2records(all_aggregates)
+        records = (datasets2records(all_aggregates)
                    .reset_index(level=0)
                    .drop('eid', axis=1))
         # Since rel_path for public FI file records starts with 'public/aggregates' instead of just
@@ -2328,7 +2333,7 @@ class OneAlyx(One):
         datetime.datetime:
             A timestamp of when the cache was updated.
         """
-        df = pd.DataFrame(next(zip(*map(util.ses2records, session_records))))
+        df = pd.DataFrame(next(zip(*map(ses2records, session_records))))
         return self._update_cache_from_records(sessions=df)
 
     def _download_datasets(self, dsets, **kwargs) -> List[Path]:
@@ -2661,7 +2666,7 @@ class OneAlyx(One):
 
     @util.refresh
     @util.parse_id
-    def eid2path(self, eid, query_type=None) -> util.Listable(Path):
+    def eid2path(self, eid, query_type=None) -> Listable(Path):
         """
         From an experiment ID gets the local session path
 
@@ -2700,7 +2705,7 @@ class OneAlyx(One):
                 str(ses[0]['number']).zfill(3))
 
     @util.refresh
-    def path2eid(self, path_obj: Union[str, Path], query_type=None) -> util.Listable(Path):
+    def path2eid(self, path_obj: Union[str, Path], query_type=None) -> Listable(Path):
         """
         From a local path, gets the experiment ID
 
@@ -2804,7 +2809,7 @@ class OneAlyx(One):
             restriction = f'session__id,{eid},dataset_type__name__in,{dataset_type}'
         else:
             raise TypeError('dataset_type must be a str or str list')
-        datasets = util.datasets2records(self.alyx.rest('datasets', 'list', django=restriction))
+        datasets = datasets2records(self.alyx.rest('datasets', 'list', django=restriction))
         return datasets if details else datasets['rel_path'].sort_values().values
 
     def dataset2type(self, dset) -> str:

--- a/one/converters.py
+++ b/one/converters.py
@@ -20,7 +20,7 @@ import pandas as pd
 from iblutil.util import Bunch, Listable, ensure_list
 
 from one.alf.spec import is_session_path, is_uuid_string
-from one.alf.cache import QC_TYPE, EMPTY_DATASETS_FRAME
+from one.alf.cache import EMPTY_DATASETS_FRAME
 from one.alf.path import (
     get_session_path, add_uuid_string, session_path_parts, get_alf_path, remove_uuid_string)
 
@@ -783,7 +783,8 @@ def ses2records(ses: dict):
         return session, EMPTY_DATASETS_FRAME.copy()
     records = map(_to_record, ses['data_dataset_session_related'])
     index = ['eid', 'id']
-    datasets = pd.DataFrame(records).set_index(index).sort_index().astype({'qc': QC_TYPE})
+    dtypes = EMPTY_DATASETS_FRAME.dtypes
+    datasets = pd.DataFrame(records).astype(dtypes).set_index(index).sort_index()
     return session, datasets
 
 
@@ -829,8 +830,7 @@ def datasets2records(datasets, additional=None) -> pd.DataFrame:
             rec[field] = d.get(field)
         records.append(rec)
 
-    index = ['eid', 'id']
     if not records:
-        keys = (*index, 'file_size', 'hash', 'session_path', 'rel_path', 'default_revision', 'qc')
-        return pd.DataFrame(columns=keys).set_index(index)
-    return pd.DataFrame(records).set_index(index).sort_index().astype({'qc': QC_TYPE})
+        return EMPTY_DATASETS_FRAME
+    index = EMPTY_DATASETS_FRAME.index.names
+    return pd.DataFrame(records).set_index(index).sort_index().astype(EMPTY_DATASETS_FRAME.dtypes)

--- a/one/tests/alf/test_alf_files.py
+++ b/one/tests/alf/test_alf_files.py
@@ -244,17 +244,5 @@ class TestALFGet(unittest.TestCase):
         self.assertRegex(str(cm.exception), 'Invalid ALF')
 
 
-class TestFilesDeprecation(unittest.TestCase):
-    """Test files module warns of deprecation."""
-
-    @staticmethod
-    def _some_function(p):
-        import one.alf.files
-        return one.alf.files.full_path_parts(p) if p else None
-
-    def test_deprecation(self):
-        self.assertWarns(FutureWarning, self._some_function, None)
-
-
 if __name__ == '__main__':
     unittest.main(exit=False, verbosity=2)

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -10,7 +10,7 @@ from iblutil.io.parquet import str2np
 from iblutil.io.params import set_hidden
 
 import one.params
-from one.util import QC_TYPE
+from one.alf.cache import QC_TYPE
 from one.converters import session_record2path
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.18
 pandas>=1.5.0
 tqdm>=4.32.1
 requests>=2.22.0
-iblutil>=1.13.0
+iblutil>=1.14.0
 packaging
 boto3
 pyyaml


### PR DESCRIPTION
Also added empty datasets and sessions frames with correct dtypes

This refactor affects:

- ibllib/oneibl/registration.py
- alyx/misc/management/commands/one_cache.py
- iblalyx/management/one_django.py
