### PR TITLE
Hotfix: download latest spike sorting BWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
-## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.11.1]
+## [Latest](https://github.com/int-brain-lab/ONE/commits/main) [2.11.2]
+
+### Modified
+
+- HOTFIX: non-default specified revisions are not ignored anymore (passed down revision argument)
+- Registration tests against Alyx > 3.2 expect empty strings as Null collections
+
+## [2.11.1]
 
 ### Modified
 

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API."""
-__version__ = '2.11.1'
+__version__ = '2.11.2'

--- a/one/api.py
+++ b/one/api.py
@@ -1013,7 +1013,7 @@ class One(ConversionMixin):
         """
         query_type = query_type or self.mode
         datasets = self.list_datasets(
-            eid, details=True, query_type=query_type, keep_eid_index=True)
+            eid, details=True, query_type=query_type, keep_eid_index=True, revision=revision)
 
         if len(datasets) == 0:
             raise alferr.ALFObjectNotFound(obj)

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -318,7 +318,7 @@ class TestRegistrationClient(unittest.TestCase):
         r, = self.client.register_files(file_list=[file])
         self.assertEqual(r['revision'], rev['name'])
         self.assertTrue(r['default'])
-        self.assertIsNone(r['collection'])
+        self.assertEqual('', r['collection'])
 
         # Register exact dataset revision again - it should append an 'a'
         # When we re-register the original it should move them into revision with today's date
@@ -337,7 +337,7 @@ class TestRegistrationClient(unittest.TestCase):
         file = files[1].parent.joinpath(f'#{r2["revision"]}#', file.name)
         self.assertTrue(file.exists())
 
-        self.assertIsNone(r3['revision'])
+        self.assertEqual('', r3['revision'])
         self.assertTrue(files[2].exists())
 
         # Protect the latest datasets


### PR DESCRIPTION
This should return True for all clusters.

```
from one.api import ONE
from brainwidemap.bwm_loading import bwm_units, load_good_units

one = ONE(base_url='https://alyx.internationalbrainlab.org', mode='remote')

units_df = bwm_units(one)
units_df = units_df.set_index(['pid', 'uuids'])

pid = units_df.pid.values[502]
spikes, clusters = load_good_units(one, pid)
set(units_df.loc[pid].index.values).issubset(set(clusters['uuids']))

```

