### PR TITLE
Use UUID objects instead of strings in cache (issue #148)

### DIFF
--- a/one/registration.py
+++ b/one/registration.py
@@ -790,7 +790,7 @@ class RegistrationClient:
         }
         # Ensure session is valid; convert to eid
         if kwargs.get('session', False):
-            wa_['session'] = self.one.to_eid(kwargs.pop('session'))
+            wa_['session'] = str(self.one.to_eid(kwargs.pop('session')) or '')
             if not wa_['session']:
                 raise ValueError('Failed to parse session ID')
 

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -91,8 +91,8 @@ class TestRegistrationClient(unittest.TestCase):
              }
         ses = self.one.alyx.rest('sessions', 'create', data=d)
         volume = random.random()
-        record = self.client.register_water_administration(self.subject, volume,
-                                                           session=ses['url'])
+        record = self.client.register_water_administration(
+            self.subject, volume, session=ses['url'])
         self.assertEqual(record['subject'], self.subject)
         self.assertEqual(record['session'], ses['url'][-36:])
         # Check validations

--- a/one/tests/util.py
+++ b/one/tests/util.py
@@ -155,8 +155,8 @@ def revisions_datasets_table(collections=('', 'alf/probe00', 'alf/probe01'),
         'hash': None,
         'exists': True,
         'qc': 'NOT_SET',
-        'eid': str(uuid4()),
-        'id': map(str, (uuid4() for _ in rel_path))
+        'eid': uuid4(),
+        'id': (uuid4() for _ in rel_path)
     }
 
     if touch_path:

--- a/one/util.py
+++ b/one/util.py
@@ -1,5 +1,6 @@
 """Decorators and small standalone functions for api module."""
 import re
+from uuid import UUID
 import logging
 import fnmatch
 import warnings
@@ -488,7 +489,9 @@ def autocomplete(term, search_terms) -> str:
 
 class LazyId(Mapping):
     """
-    Using a paginated response object or list of session records, extracts eid string when required
+    Return UUID from records when indexed.
+
+    Uses a paginated response object or list of Alyx REST records.
     """
     def __init__(self, pg, func=None):
         self._pg = pg
@@ -520,4 +523,5 @@ class LazyId(Mapping):
         if isinstance(ses, list):
             return [LazyId.ses2eid(x) for x in ses]
         else:
-            return ses.get('id', None) or ses['url'].split('/').pop()
+            eid = ses.get('id', None) or ses['url'].split('/').pop()
+            return UUID(eid)


### PR DESCRIPTION
This PR sees str indices replaced by UUID objects in the cache tables, and to have them returned by methods such as `to_eid`, `search` and `search_insertions`. One reason for this is to reduce the memory footprint of the cache table indices to improve scalability.  A UUID object is 56 bytes in memory vs 85 bytes for the str representation. As an int this is 44 bytes.  Loading times take a hit as UUID objects are not a supported parquet data type and thus need to be cast before saving and after loading. This compromise is worth it as we move away from loading large tables upon instantiation. Other table formats such as feather support UUID objects. UUIDs are immutable, interconvertible, and have the added advantage of validation at instantiation.

All ONE methods already support either str or UUID inputs, and AlyxClient.rest supports UUID inputs for the id kwarg.  One major cause of issues will be string formatting with these objects, e.g. `alyx.rest.list('sessions', django=f'pk,{eid}')` will no longer work and should be changed to `alyx.rest.list('sessions', django=f'pk,{str(eid)}')`. Additionally if you previously cast your strings to UUIDs, this will now raise an error (unlike `str(str(eid))`, `UUID(UUID(eid))` is not allowed)