### PR TITLE
one.api bugfix: one.load_object should not enforce strict revision

### DIFF
--- a/one/api.py
+++ b/one/api.py
@@ -1025,7 +1025,7 @@ class One(ConversionMixin):
         """
         query_type = query_type or self.mode
         datasets = self.list_datasets(
-            eid, details=True, query_type=query_type, keep_eid_index=True, revision=revision)
+            eid, details=True, query_type=query_type, keep_eid_index=True)
 
         if len(datasets) == 0:
             raise alferr.ALFObjectNotFound(obj)


### PR DESCRIPTION
The revision parameter was parsed twice: once in a strict manner line 1028, and then getting the last revision before a date in line 1035.

The strict check line 1028 is unnecessary and harmful if the revision doesn't exist.