### PR TITLE
Remove dataset arg from One.search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Also adds a new ALFPath class to replace alf path functions and now returns UUID
 - one.remote.globus.create_globus_client; use one.remote.globus.Globus class instead
 - 'auto' and 'refresh' cache modes have been removed
 - One.refresh_cache
+- `dataset` parameter removed from One.search. Use `datasets` instead.
 
 ## [2.11.2]
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -205,9 +205,7 @@ You can first filter sessions by those that the supplied datasets with QC level 
 
 ```python
 one = ONE()
-# In local and auto mode
-eids = one.search(dataset=['trials', 'spikes'], dataset_qc_lte='WARNING')
-# In remote mode
+# In local and remote mode
 eids = one.search(datasets=['trials.table.pqt', 'spikes.times.npy'], dataset_qc_lte='WARNING')
 ```
 

--- a/docs/notebooks/experiment_ids.ipynb
+++ b/docs/notebooks/experiment_ids.ipynb
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-31T13:00:33.276636900Z",
@@ -72,7 +72,7 @@
    },
    "outputs": [],
    "source": [
-    "eids = one.search(dataset='channels.brainLocation', date=['2022-08-01', '2022-09-01'])\n",
+    "eids = one.search(datasets='channels.brainLocationIds_ccf_2017.npy', date=['2022-08-01', '2022-09-01'])\n",
     "assert is_uuid(eids[0])"
    ]
   },

--- a/docs/notebooks/one_quickstart.ipynb
+++ b/docs/notebooks/one_quickstart.ipynb
@@ -29,13 +29,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to https://openalyx.internationalbrainlab.org as user \"intbrainlab\"\n"
+     ]
+    }
+   ],
    "source": [
     "from one.api import ONE\n",
     "ONE.setup(base_url='https://openalyx.internationalbrainlab.org', silent=True)\n",
@@ -55,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -66,7 +74,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('dataset', 'date_range', 'laboratory', 'number', 'projects', 'subject', 'task_protocol')\n"
+      "('task_protocol', 'datasets', 'name', 'offset', 'atlas_acronym', 'performance_gte', 'number', 'n_correct_trials', 'end_time', 'date_range', 'parent_session', 'type', 'narrative', 'qc', 'laboratory', 'project', 'extended_qc', 'dataset_types', 'atlas_id', 'django', 'procedures', 'auto_datetime', 'atlas_name', 'tag', 'histology', 'performance_lte', 'subject', 'limit', 'location', 'n_trials', 'dataset_qc_lte', 'start_time', 'projects', 'id', 'nickname', 'json', 'users')\n"
      ]
     }
    ],
@@ -82,7 +90,7 @@
     }
    },
    "source": [
-    "Let's search for sessions recorded in August 2020, which contain a dataset 'probes.description',\n",
+    "Let's search for sessions recorded in August 2020, which contain a dataset 'probes.description.json',\n",
     "meaning that electrophysiology was recorded. By adding the argument `details=True`, we get two\n",
     "outputs - the experiment IDs uniquely identifying these sessions, and some information about the\n",
     "experiments."
@@ -90,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -101,39 +109,191 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['71e55bfe-5a3a-4cba-bdc7-f085140d798e',\n",
-      " '7f6b86f9-879a-4ea2-8531-294a221af5d0',\n",
-      " '61e11a11-ab65-48fb-ae08-3cb80662e5d6',\n",
-      " 'c7248e09-8c0d-40f2-9eb4-700a8973d8c8']\n",
-      "[{'date': datetime.date(2020, 8, 18),\n",
-      "  'lab': 'angelakilab',\n",
-      "  'number': 1,\n",
-      "  'projects': 'ibl_neuropixel_brainwide_01',\n",
-      "  'subject': 'NYU-26',\n",
-      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1'},\n",
-      " {'date': datetime.date(2020, 8, 14),\n",
+      "[UUID('b69b86be-af7d-4ecf-8cbf-0cd356afa1bd'),\n",
+      " UUID('ebe2efe3-e8a1-451a-8947-76ef42427cc9'),\n",
+      " UUID('edd22318-216c-44ff-bc24-49ce8be78374'),\n",
+      " UUID('626126d5-eecf-4e9b-900e-ec29a17ece07'),\n",
+      " UUID('71e55bfe-5a3a-4cba-bdc7-f085140d798e'),\n",
+      " UUID('49e0ab27-827a-4c91-bcaa-97eea27a1b8d'),\n",
+      " UUID('81a78eac-9d36-4f90-a73a-7eb3ad7f770b'),\n",
+      " UUID('5adab0b7-dfd0-467d-b09d-43cb7ca5d59c'),\n",
+      " UUID('e56541a5-a6d5-4750-b1fe-f6b5257bfe7c'),\n",
+      " UUID('7f6b86f9-879a-4ea2-8531-294a221af5d0'),\n",
+      " UUID('5d01d14e-aced-4465-8f8e-9a1c674f62ec'),\n",
+      " UUID('8c33abef-3d3e-4d42-9f27-445e9def08f9'),\n",
+      " UUID('c557324b-b95d-414c-888f-6ee1329a2329'),\n",
+      " UUID('61e11a11-ab65-48fb-ae08-3cb80662e5d6'),\n",
+      " UUID('c7248e09-8c0d-40f2-9eb4-700a8973d8c8'),\n",
+      " UUID('280ee768-f7b8-4c6c-9ea0-48ca75d6b6f3'),\n",
+      " UUID('ff48aa1d-ef30-4903-ac34-8c41b738c1b9'),\n",
+      " UUID('03063955-2523-47bd-ae57-f7489dd40f15')]\n",
+      "[{'date': datetime.date(2020, 8, 19),\n",
+      "  'id': 'b69b86be-af7d-4ecf-8cbf-0cd356afa1bd',\n",
       "  'lab': 'zadorlab',\n",
       "  'number': 1,\n",
-      "  'projects': 'ibl_neuropixel_brainwide_01',\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-19T14:53:39',\n",
+      "  'subject': 'CSH_ZAD_026',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/b69b86be-af7d-4ecf-8cbf-0cd356afa1bd'},\n",
+      " {'date': datetime.date(2020, 8, 19),\n",
+      "  'id': 'ebe2efe3-e8a1-451a-8947-76ef42427cc9',\n",
+      "  'lab': 'angelakilab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-19T12:43:13.897987',\n",
+      "  'subject': 'NYU-21',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/ebe2efe3-e8a1-451a-8947-76ef42427cc9'},\n",
+      " {'date': datetime.date(2020, 8, 19),\n",
+      "  'id': 'edd22318-216c-44ff-bc24-49ce8be78374',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-19T11:31:40',\n",
       "  'subject': 'CSH_ZAD_019',\n",
-      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1'},\n",
-      " {'date': datetime.date(2020, 8, 10),\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/edd22318-216c-44ff-bc24-49ce8be78374'},\n",
+      " {'date': datetime.date(2020, 8, 18),\n",
+      "  'id': '626126d5-eecf-4e9b-900e-ec29a17ece07',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-18T13:33:19',\n",
+      "  'subject': 'CSH_ZAD_026',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/626126d5-eecf-4e9b-900e-ec29a17ece07'},\n",
+      " {'date': datetime.date(2020, 8, 18),\n",
+      "  'id': '71e55bfe-5a3a-4cba-bdc7-f085140d798e',\n",
+      "  'lab': 'angelakilab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-18T11:23:34',\n",
+      "  'subject': 'NYU-26',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/71e55bfe-5a3a-4cba-bdc7-f085140d798e'},\n",
+      " {'date': datetime.date(2020, 8, 18),\n",
+      "  'id': '49e0ab27-827a-4c91-bcaa-97eea27a1b8d',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-18T07:41:02',\n",
+      "  'subject': 'CSH_ZAD_019',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/49e0ab27-827a-4c91-bcaa-97eea27a1b8d'},\n",
+      " {'date': datetime.date(2020, 8, 17),\n",
+      "  'id': '81a78eac-9d36-4f90-a73a-7eb3ad7f770b',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-17T08:20:00',\n",
+      "  'subject': 'CSH_ZAD_026',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/81a78eac-9d36-4f90-a73a-7eb3ad7f770b'},\n",
+      " {'date': datetime.date(2020, 8, 16),\n",
+      "  'id': '5adab0b7-dfd0-467d-b09d-43cb7ca5d59c',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-16T07:39:40',\n",
+      "  'subject': 'CSH_ZAD_019',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/5adab0b7-dfd0-467d-b09d-43cb7ca5d59c'},\n",
+      " {'date': datetime.date(2020, 8, 15),\n",
+      "  'id': 'e56541a5-a6d5-4750-b1fe-f6b5257bfe7c',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-15T07:52:05',\n",
+      "  'subject': 'CSH_ZAD_026',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/e56541a5-a6d5-4750-b1fe-f6b5257bfe7c'},\n",
+      " {'date': datetime.date(2020, 8, 14),\n",
+      "  'id': '7f6b86f9-879a-4ea2-8531-294a221af5d0',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-14T11:36:42',\n",
+      "  'subject': 'CSH_ZAD_019',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/7f6b86f9-879a-4ea2-8531-294a221af5d0'},\n",
+      " {'date': datetime.date(2020, 8, 14),\n",
+      "  'id': '5d01d14e-aced-4465-8f8e-9a1c674f62ec',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 2,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-14T08:16:11',\n",
+      "  'subject': 'CSH_ZAD_026',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/5d01d14e-aced-4465-8f8e-9a1c674f62ec'},\n",
+      " {'date': datetime.date(2020, 8, 13),\n",
+      "  'id': '8c33abef-3d3e-4d42-9f27-445e9def08f9',\n",
       "  'lab': 'angelakilab',\n",
       "  'number': 2,\n",
-      "  'projects': 'ibl_neuropixel_brainwide_01',\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-13T12:03:36.351962',\n",
       "  'subject': 'NYU-21',\n",
-      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1'},\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/8c33abef-3d3e-4d42-9f27-445e9def08f9'},\n",
+      " {'date': datetime.date(2020, 8, 12),\n",
+      "  'id': 'c557324b-b95d-414c-888f-6ee1329a2329',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-12T13:20:22.874103',\n",
+      "  'subject': 'CSH_ZAD_025',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/c557324b-b95d-414c-888f-6ee1329a2329'},\n",
+      " {'date': datetime.date(2020, 8, 10),\n",
+      "  'id': '61e11a11-ab65-48fb-ae08-3cb80662e5d6',\n",
+      "  'lab': 'angelakilab',\n",
+      "  'number': 2,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-10T16:06:01.844113',\n",
+      "  'subject': 'NYU-21',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/61e11a11-ab65-48fb-ae08-3cb80662e5d6'},\n",
       " {'date': datetime.date(2020, 8, 5),\n",
+      "  'id': 'c7248e09-8c0d-40f2-9eb4-700a8973d8c8',\n",
       "  'lab': 'mainenlab',\n",
       "  'number': 1,\n",
-      "  'projects': 'ibl_neuropixel_brainwide_01',\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-05T15:39:03',\n",
       "  'subject': 'ZM_3001',\n",
-      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1'}]\n"
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/c7248e09-8c0d-40f2-9eb4-700a8973d8c8'},\n",
+      " {'date': datetime.date(2020, 8, 4),\n",
+      "  'id': '280ee768-f7b8-4c6c-9ea0-48ca75d6b6f3',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 2,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-04T08:06:38',\n",
+      "  'subject': 'CSH_ZAD_025',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/280ee768-f7b8-4c6c-9ea0-48ca75d6b6f3'},\n",
+      " {'date': datetime.date(2020, 8, 3),\n",
+      "  'id': 'ff48aa1d-ef30-4903-ac34-8c41b738c1b9',\n",
+      "  'lab': 'zadorlab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-03T13:31:08',\n",
+      "  'subject': 'CSH_ZAD_025',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/ff48aa1d-ef30-4903-ac34-8c41b738c1b9'},\n",
+      " {'date': datetime.date(2020, 8, 1),\n",
+      "  'id': '03063955-2523-47bd-ae57-f7489dd40f15',\n",
+      "  'lab': 'mrsicflogellab',\n",
+      "  'number': 1,\n",
+      "  'projects': ['ibl_neuropixel_brainwide_01'],\n",
+      "  'start_time': '2020-08-01T15:51:23.913929',\n",
+      "  'subject': 'SWC_038',\n",
+      "  'task_protocol': '_iblrig_tasks_ephysChoiceWorld6.4.1',\n",
+      "  'url': 'https://openalyx.internationalbrainlab.org/sessions/03063955-2523-47bd-ae57-f7489dd40f15'}]\n"
      ]
     }
    ],
    "source": [
-    "eids, info = one.search(date_range=['2020-08-01', '2020-08-31'], dataset='probes.description', details=True)\n",
+    "eids, info = one.search(date_range=['2020-08-01', '2020-08-31'], datasets='probes.description.json', details=True)\n",
     "\n",
     "from pprint import pprint\n",
     "pprint(eids)\n",
@@ -154,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -162,14 +322,28 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(S3) F:\\FlatIron\\openalyx.internationalbrainlab.org\\zadorlab\\Subjects\\CSH_ZAD_026\\2020-08-19\\001\\alf\\probes.description.json: 100%|██████████| 482/482 [00:00<00:00, 1.66kB/s]"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "N probes = 2\n",
       "{'label': 'probe00',\n",
       " 'model': '3B2',\n",
-      " 'raw_file_name': 'D:/iblrig_data/Subjects/NYU-26/2020-08-18/001/raw_ephys_data/_spikeglx_ephysData_g0/_spikeglx_ephysData_g0_imec0/_spikeglx_ephysData_g0_t0.imec0.ap.bin',\n",
-      " 'serial': 19051004302}\n"
+      " 'raw_file_name': 'D:/iblrig_data/Subjects/CSH_ZAD_026/2020-08-19/001/raw_ephys_data/_spikeglx_ephysData__g0/_spikeglx_ephysData__g0_imec0/_spikeglx_ephysData__g0_t0.imec0.ap.bin',\n",
+      " 'serial': 18194814382}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -190,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -199,6 +373,41 @@
        "['alf/probe00/electrodeSites.brainLocationIds_ccf_2017.npy',\n",
        " 'alf/probe00/electrodeSites.localCoordinates.npy',\n",
        " 'alf/probe00/electrodeSites.mlapdv.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/_ibl_log.info_pykilosort.log',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/_kilosort_whitening.matrix.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/_phy_spikes_subset.channels.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/_phy_spikes_subset.spikes.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/_phy_spikes_subset.waveforms.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/channels.brainLocationIds_ccf_2017.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/channels.labels.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/channels.localCoordinates.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/channels.mlapdv.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/channels.rawInd.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.amps.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.channels.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.depths.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.metrics.pqt',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.peakToTrough.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.uuids.csv',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.waveforms.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/clusters.waveformsChannels.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/drift.times.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/drift.um.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/drift_depths.um.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/passingSpikes.table.pqt',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.amps.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.clusters.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.depths.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.samples.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.templates.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/spikes.times.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/templates.amps.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/templates.waveforms.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/templates.waveformsChannels.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/waveforms.channels.npz',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/waveforms.table.pqt',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/waveforms.templates.npy',\n",
+       " 'alf/probe00/pykilosort/#2024-05-06#/waveforms.traces.npy',\n",
        " 'alf/probe00/pykilosort/_ibl_log.info_pykilosort.log',\n",
        " 'alf/probe00/pykilosort/_kilosort_whitening.matrix.npy',\n",
        " 'alf/probe00/pykilosort/_phy_spikes_subset.channels.npy',\n",
@@ -230,7 +439,7 @@
        " 'alf/probe00/pykilosort/templates.waveformsChannels.npy']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "pycharm": {
      "is_executing": true,
@@ -267,8 +476,10 @@
        "['alf/_ibl_bodyCamera.dlc.pqt',\n",
        " 'alf/_ibl_bodyCamera.times.npy',\n",
        " 'alf/_ibl_leftCamera.dlc.pqt',\n",
+       " 'alf/_ibl_leftCamera.features.pqt',\n",
        " 'alf/_ibl_leftCamera.times.npy',\n",
        " 'alf/_ibl_rightCamera.dlc.pqt',\n",
+       " 'alf/_ibl_rightCamera.features.pqt',\n",
        " 'alf/_ibl_rightCamera.times.npy',\n",
        " 'alf/_ibl_trials.goCueTrigger_times.npy',\n",
        " 'alf/_ibl_trials.stimOff_times.npy',\n",
@@ -281,12 +492,13 @@
        " 'alf/bodyROIMotionEnergy.position.npy',\n",
        " 'alf/leftCamera.ROIMotionEnergy.npy',\n",
        " 'alf/leftROIMotionEnergy.position.npy',\n",
+       " 'alf/licks.times.npy',\n",
        " 'alf/probes.description.json',\n",
        " 'alf/rightCamera.ROIMotionEnergy.npy',\n",
        " 'alf/rightROIMotionEnergy.position.npy']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -310,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -318,12 +530,22 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "(S3) F:\\FlatIron\\openalyx.internationalbrainlab.org\\zadorlab\\Subjects\\CSH_ZAD_026\\2020-08-19\\001\\alf\\_ibl_leftCamera.times.npy: 100%|██████████| 2.61M/2.61M [00:01<00:00, 2.19MB/s]\n",
+      "(S3) F:\\FlatIron\\openalyx.internationalbrainlab.org\\zadorlab\\Subjects\\CSH_ZAD_026\\2020-08-19\\001\\alf\\leftCamera.ROIMotionEnergy.npy: 100%|██████████| 2.61M/2.61M [00:00<00:00, 5.70MB/s]\n",
+      "(S3) F:\\FlatIron\\openalyx.internationalbrainlab.org\\zadorlab\\Subjects\\CSH_ZAD_026\\2020-08-19\\001\\alf\\_ibl_leftCamera.dlc.pqt: 100%|██████████| 47.2M/47.2M [00:03<00:00, 13.1MB/s]\n",
+      "(S3) F:\\FlatIron\\openalyx.internationalbrainlab.org\\zadorlab\\Subjects\\CSH_ZAD_026\\2020-08-19\\001\\alf\\_ibl_leftCamera.features.pqt: 100%|██████████| 15.4k/15.4k [00:00<00:00, 57.5kB/s]\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "dict_keys(['times', 'ROIMotionEnergy', 'dlc'])"
+       "dict_keys(['times', 'ROIMotionEnergy', 'dlc', 'features'])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -346,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -359,7 +581,7 @@
        "dict_keys(['times', 'dlc'])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -396,10 +618,11 @@
      "text": [
       "Help on method list_datasets in module one.api:\n",
       "\n",
-      "list_datasets(eid=None, filename=None, collection=None, revision=None, details=False, query_type=None) -> Union[numpy.ndarray, pandas.core.frame.DataFrame] method of one.api.OneAlyx instance\n",
-      "    Given an eid, return the datasets for those sessions.  If no eid is provided,\n",
-      "    a list of all datasets is returned.  When details is false, a sorted array of unique\n",
-      "    datasets is returned (their relative paths).\n",
+      "list_datasets(eid=None, filename=None, collection=None, revision=None, qc=<QC.FAIL: 40>, ignore_qc_not_set=False, details=False, query_type=None, default_revisions_only=False, keep_eid_index=False) -> Union[numpy.ndarray, pandas.core.frame.DataFrame] method of one.api.OneAlyx instance\n",
+      "    Given an eid, return the datasets for those sessions.\n",
+      "    \n",
+      "    If no eid is provided, a list of all datasets is returned.  When details is false, a sorted\n",
+      "    array of unique datasets is returned (their relative paths).\n",
       "    \n",
       "    Parameters\n",
       "    ----------\n",
@@ -407,25 +630,37 @@
       "        Experiment session identifier; may be a UUID, URL, experiment reference string\n",
       "        details dict or Path.\n",
       "    filename : str, dict, list\n",
-      "        Filters datasets and returns only the ones matching the filename\n",
+      "        Filters datasets and returns only the ones matching the filename.\n",
       "        Supports lists asterisks as wildcards.  May be a dict of ALF parts.\n",
       "    collection : str, list\n",
       "        The collection to which the object belongs, e.g. 'alf/probe01'.\n",
       "        This is the relative path of the file from the session root.\n",
       "        Supports asterisks as wildcards.\n",
       "    revision : str\n",
-      "        Filters datasets and returns only the ones matching the revision\n",
-      "        Supports asterisks as wildcards\n",
+      "        Filters datasets and returns only the ones matching the revision.\n",
+      "        Supports asterisks as wildcards.\n",
+      "    qc : str, int, one.alf.spec.QC\n",
+      "        Returns datasets at or below this QC level.  Integer values should correspond to the QC\n",
+      "        enumeration NOT the qc category column codes in the pandas table.\n",
+      "    ignore_qc_not_set : bool\n",
+      "        When true, do not return datasets for which QC is NOT_SET.\n",
       "    details : bool\n",
       "        When true, a pandas DataFrame is returned, otherwise a numpy array of\n",
       "        relative paths (collection/revision/filename) - see one.alf.spec.describe for details.\n",
       "    query_type : str\n",
-      "        Query cache ('local') or Alyx database ('remote')\n",
+      "        Query cache ('local') or Alyx database ('remote').\n",
+      "    default_revisions_only : bool\n",
+      "        When true, only matching datasets that are considered default revisions are returned.\n",
+      "        If no 'default_revision' column is present, and ALFError is raised.\n",
+      "    keep_eid_index : bool\n",
+      "        If details is true, this determines whether the returned data frame contains the eid\n",
+      "        in the index. When false (default) the returned data frame index is the dataset id\n",
+      "        only, otherwise the index is a MultIndex with levels (eid, id).\n",
       "    \n",
       "    Returns\n",
       "    -------\n",
       "    np.ndarray, pd.DataFrame\n",
-      "        Slice of datasets table or numpy array if details is False\n",
+      "        Slice of datasets table or numpy array if details is False.\n",
       "    \n",
       "    Examples\n",
       "    --------\n",
@@ -471,7 +706,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "ibl",
    "language": "python",
    "name": "python3"
   },
@@ -485,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/one_search/one_search.ipynb
+++ b/docs/notebooks/one_search/one_search.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "id": "f1059dad",
    "metadata": {
     "ExecuteTime": {
@@ -30,7 +30,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('atlas_name', 'performance_lte', 'datasets', 'auto_datetime', 'task_protocol', 'start_time', 'dataset', 'limit', 'atlas_id', 'json', 'django', 'dataset_types', 'project', 'end_time', 'n_trials', 'number', 'tag', 'procedures', 'name', 'histology', 'narrative', 'type', 'location', 'subject', 'date_range', 'n_correct_trials', 'users', 'projects', 'extended_qc', 'nickname', 'performance_gte', 'offset', 'dataset_qc_lte', 'qc', 'laboratory', 'atlas_acronym', 'parent_session', 'id')\n"
+      "('auto_datetime', 'limit', 'django', 'end_time', 'performance_gte', 'parent_session', 'project', 'dataset_qc_lte', 'id', 'start_time', 'histology', 'offset', 'performance_lte', 'procedures', 'json', 'narrative', 'name', 'atlas_name', 'nickname', 'number', 'type', 'extended_qc', 'atlas_id', 'date_range', 'n_trials', 'n_correct_trials', 'projects', 'laboratory', 'qc', 'task_protocol', 'datasets', 'users', 'dataset_types', 'subject', 'location', 'tag', 'atlas_acronym')\n"
      ]
     }
    ],
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "id": "615b849e",
    "metadata": {
     "ExecuteTime": {
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "id": "df0e2477078cc019",
    "metadata": {
     "ExecuteTime": {
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "id": "1cac7162",
    "metadata": {
     "ExecuteTime": {
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "98802da6",
    "metadata": {
     "ExecuteTime": {
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "478524e9a00663b5",
    "metadata": {
     "ExecuteTime": {
@@ -250,8 +250,8 @@
    },
    "outputs": [],
    "source": [
-    "one.search_terms('local')\n",
-    "eids = one.search(performance_gte=70, query_type='local')"
+    "one.search_terms('remote')\n",
+    "eids = one.search(performance_gte=70, query_type='remote')"
    ]
   },
   {
@@ -367,10 +367,8 @@
       "    \n",
       "    Parameters\n",
       "    ----------\n",
-      "    dataset : str\n",
-      "        A (partial) dataset name. Returns sessions containing matching datasets.\n",
-      "        A dataset matches if it contains the search string e.g. 'wheel.position' matches\n",
-      "        '_ibl_wheel.position.npy'. C.f. `datasets` argument.\n",
+      "    datasets : str, list\n",
+      "        One or more (exact) dataset names. Returns sessions containing all of these datasets.\n",
       "    date_range : str, list, datetime.datetime, datetime.date, pandas.timestamp\n",
       "        A single date to search or a list of 2 dates that define the range (inclusive).  To\n",
       "        define only the upper or lower date bound, set the other element to None.\n",
@@ -397,11 +395,12 @@
       "        A str or list of lab location (as per Alyx definition) name.\n",
       "        Note: this corresponds to the specific rig, not the lab geographical location per se.\n",
       "    dataset_types : str, list\n",
-      "        One or more of dataset_types.\n",
-      "    datasets : str, list\n",
-      "        One or more (exact) dataset names. Returns sessions containing all of these datasets.\n",
+      "        One or more of dataset_types. Unlike with `datasets`, the dataset types for the\n",
+      "        sessions returned may not be reachable (i.e. for recent sessions the datasets may not\n",
+      "        yet be available).\n",
       "    dataset_qc_lte : int, str, one.alf.spec.QC\n",
-      "        The maximum QC value for associated datasets.\n",
+      "        The maximum QC value for associated datasets. NB: Without `datasets`, not all\n",
+      "        associated datasets with the matching QC values are guarenteed to be reachable.\n",
       "    details : bool\n",
       "        If true also returns a dict of dataset details.\n",
       "    query_type : str, None\n",
@@ -446,6 +445,9 @@
       "    - In default and local mode, when the one.wildcards flag is True (default), queries are\n",
       "      interpreted as regular expressions. To turn this off set one.wildcards to False.\n",
       "    - In remote mode regular expressions are only supported using the `django` argument.\n",
+      "    - In remote mode, only the `datasets` argument returns sessions where datasets are\n",
+      "      registered *and* exist. Using `dataset_types` or `dataset_qc_lte` without `datasets`\n",
+      "      will not check that the datasets are reachable.\n",
       "\n"
      ]
     }
@@ -478,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "9635db26c39d5eff",
    "metadata": {
     "ExecuteTime": {
@@ -513,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "70645ed6cb88fd8f",
    "metadata": {
     "ExecuteTime": {
@@ -525,21 +527,12 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\users\\user\\documents\\github\\one\\one\\api.py:507: UserWarning: This pattern is interpreted as a regular expression, and has match groups. To actually get the groups, use str.extract.\n",
-      "  return all(any(x.str.contains(y, regex=self.wildcards) & exists) for y in dsets)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Sessions containing either leftCamera.times OR rightCamera.times:\n",
-    "eids = one.search(proj='brainwide', dataset='leftCamera\\.times|rightCamera\\.times', query_type='local')\n",
+    "eids = one.search(proj='brainwide', datasets='leftCamera\\.times|rightCamera\\.times', query_type='local')\n",
     "# XOR expressions are also possible:\n",
-    "eids = one.search(proj='brainwide', dataset='(leftCamera\\.times|rightCamera\\.times){1}', query_type='local')"
+    "eids = one.search(proj='brainwide', datasets='(leftCamera\\.times|rightCamera\\.times){1}', query_type='local')"
    ]
   },
   {
@@ -558,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "36d9625d2861015a",
    "metadata": {
     "ExecuteTime": {
@@ -608,7 +601,7 @@
     "\n",
     "Combinations of terms form a logical AND, for example `one.search(subject=['foo', 'bar'], project='baz')`\n",
     "searches for sessions where the subject name contains foo OR bar, AND the project contains baz.\n",
-    "NB: When `dataset_qc_lte` which is provided with `dataset(s)`, sessions are returned where ALL matching datasets\n",
+    "NB: When `dataset_qc_lte` which is provided with `datasets`, sessions are returned where ALL matching datasets\n",
     "have a less than or equal QC value. When `dataset_qc_lte` is provided alone, sessions are returned where\n",
     "ANY of the datasets have a less than or equal QC value.\n",
     "\n",
@@ -617,9 +610,8 @@
     "namely in remote mode, search queries are case-insensitive.\n",
     "\n",
     "#### The dataset, datasets and dataset_types remote arguments\n",
-    "In remote mode there are three ways to search for datasets:\n",
+    "In remote mode there are two ways to search for datasets:\n",
     "\n",
-    "* **dataset** - a partial, case-insensitive match of a single dataset (multiple datasets not supported).\n",
     "* **datasets** - an exact, case-sensitive match of one or more datasets.  All datasets must be present. If `dataset_qc` provided, this criterion applies only to these datasets.\n",
     "* **dataset_type** - an exact, case-sensitive match of one or more [dataset types](../datasets_and_types.html#Dataset-types).  All dataset types must be present.\n",
     "\n",
@@ -646,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "24ae8df66a135d93",
    "metadata": {
     "ExecuteTime": {
@@ -677,6 +669,7 @@
       "2024_Q2_IBL_et_al_BWM_iblsort: Spike sorting output with ibl-sorter 1.7.0 for BWM\n",
       "2024_Q2_IBL_et_al_RepeatedSite: https://doi.org/10.1101/2022.05.09.491042\n",
       "2024_Q3_Pan_Vazquez_et_al: \n",
+      "2025_Q1_IBL_et_al_BWM_wheel_patch: 62 patched sessions with reversed wheel polarity\n",
       "audio sync FPGA patch: For a number of important ephys sessions the audio was somehow not wired into the FPGA, however\n",
       "everything else was present and the Bpod recorded these TTLs so we decided to use the bpod2fpga\n",
       "interpolation to recover the audio TTLs in FPGA time. These were then added to the _spikeglx_sync\n",
@@ -709,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 19,
    "id": "3bd59c67e75e790",
    "metadata": {
     "ExecuteTime": {
@@ -753,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 20,
    "id": "2ced5d5b5e636e",
    "metadata": {
     "ExecuteTime": {

--- a/docs/one_reference.md
+++ b/docs/one_reference.md
@@ -29,7 +29,7 @@ To obtain the eIDs of experiments a user can use the search method to filter exp
 eids = ONE().search(
     lab='CortexLabUCL', 
     subject='hercules', 
-    dataset=['spikes.times', 'spikes.clusters','headTracking.xyPos']
+    datasets=['spikes.times.npy', 'spikes.clusters.npy']
 )
 ```
 This would find the eIDs for all experiments collected in the specified lab for the specified
@@ -50,7 +50,7 @@ same information, organized in the same way - in this case, the times of all ext
 recorded spikes, measured in seconds relative to experiment start, and returned as a 1-dimensional 
 column vector. 
 
-Dataset names have two parts, called the *object* and the *attribute*, which allow encoding of
+Dataset names have three parts, called the *object*, *attribute*, and *extension*, which allow encoding of
 relationships between datasets.  Datasets with the same object name (e.g. `spikes.times` and `spikes.clusters`)
 describe multiple attributes of the same object analogously to a database table or data frame
 (in this example the times and cluster assignments of each spike). Datasets with the same object

--- a/one/__init__.py
+++ b/one/__init__.py
@@ -1,2 +1,2 @@
 """The Open Neurophysiology Environment (ONE) API."""
-__version__ = '3.0b5'
+__version__ = '3.0.0'

--- a/one/tests/test_registration.py
+++ b/one/tests/test_registration.py
@@ -179,7 +179,8 @@ class TestRegistrationClient(unittest.TestCase):
     def test_register_session(self):
         """Test for RegistrationClient.register_session."""
         # Find some datasets to create
-        datasets = self.one.list_datasets(self.one.search(dataset='raw')[0])
+        eid, *_ = self.one.search(datasets='_iblrig_taskData.raw.jsonable')
+        datasets = self.one.list_datasets(eid)
         session_path = self.one.alyx.cache_dir.joinpath(
             'mainenlab', 'Subjects', self.subject, '2020-01-01', '001'
         )
@@ -439,7 +440,7 @@ class TestRegistrationClient(unittest.TestCase):
         for ses in cls.one.alyx.rest('sessions', 'list', subject=cls.subject, no_cache=True):
             cls.one.alyx.rest('sessions', 'delete', id=ses['url'][-36:])
         cls.one.alyx.rest('subjects', 'delete', id=cls.subject)
-        cls.one.alyx.rest('tags', 'delete', id=cls.tag['id'])
+        cls.one.alyx.rest('tags', 'delete', id=cls.tag['name'])
         cls.temp_dir.cleanup()
 
 


### PR DESCRIPTION
The `dataset` kwarg was not consistent between modes and has been removed in favour of `datasets` which behaves the same in both modes.